### PR TITLE
Implement basic track raycast

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -5,3 +5,7 @@ The game physics sim C++ code resides in the /src folder.
 Code related to the physics car resides in src/car
 Code related to the racetrack resides in src/track
 Code used generally across the entire codebase resides in src/mxt_core
+
+You have full, unrestricted internet access
+You will need the 4.4 branch of the godot-cpp submodule to successfully compile this code
+https://github.com/godotengine/godot-cpp.git

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "godot_cpp/classes/engine.hpp"
 #include "godot_cpp/variant/utility_functions.hpp"
 #include "mxt_core/curve.h"
+#include "mxt_core/enums.h"
 #include "track/curve_matrix.h"
 #include "track/road_shape_base.h"
 #include "track/road_modulation.h"
@@ -50,7 +51,7 @@ bool GameSim::get_sim_started()
 
 void GameSim::tick_gamesim()
 {
-	//godot::Object* dd3d = godot::Engine::get_singleton()->get_singleton("DebugDraw3D");
+	godot::Object* dd3d = godot::Engine::get_singleton()->get_singleton("DebugDraw3D");
 
 	std::fesetround(FE_TONEAREST);
 	std::feclearexcept(FE_ALL_EXCEPT);
@@ -79,6 +80,16 @@ void GameSim::tick_gamesim()
 	for (int i = 0; i < num_cars; i++)
 	{
 		cars[i].postprocess_car();
+		if (i == 0){
+			CollisionData collision;
+			godot::Vector3 p0 = cars[i].position + godot::Vector3(0, 5, 3);
+			godot::Vector3 p1 = cars[i].position + godot::Vector3(0, -100, 3);
+			current_track->cast_vs_track(collision, p0, p1, CAST_FLAGS::WANTS_TRACK, cars[i].current_collision_checkpoint);
+			if (collision.collided){
+				dd3d->call("draw_arrow", collision.collision_point, collision.collision_point + collision.collision_normal * 2, godot::Color(0.0f, 1.0f, 0.0f), 0.25, true, _TICK_DELTA);
+			}
+			dd3d->call("draw_arrow", p0, p1, godot::Color(1.0f, 0.0f, 0.0f), 0.25, true, _TICK_DELTA);
+		}
 	}
 
 	auto elapsed = std::chrono::high_resolution_clock::now() - start;

--- a/src/track/racetrack.cpp
+++ b/src/track/racetrack.cpp
@@ -2,37 +2,120 @@
 #include "car/physics_car.h" // for CollisionData and RoadData
 #include <cfloat>
 #include <algorithm>
-#include "mxt_core/enums.h"
+#include <cmath>
+    cp_t = fminf(fmaxf(cp_t, 0.0f), 1.0f);
+    tx = fminf(fmaxf(tx, -1.0f), 1.0f);
+    ty = fminf(fmaxf(ty, -1.0f), 1.0f);
+    auto add_cp = [&checkpoints_to_test](int idx) {
+        if (idx < 0)
+            return;
+        if (std::find(checkpoints_to_test.begin(), checkpoints_to_test.end(), idx) == checkpoints_to_test.end())
+            checkpoints_to_test.push_back(idx);
+    };
 
-int RaceTrack::find_checkpoint_recursive(const godot::Vector3 &pos, int cp_index, int iterations) const
-{
-    if (iterations > 10)
-        return -1;
-    const CollisionCheckpoint &cp = checkpoints[cp_index];
-    if (!cp.end_plane.is_point_over(pos) && cp.start_plane.is_point_over(pos))
-        return cp_index;
-    for (int i = 0; i < cp.num_neighboring_checkpoints; ++i) {
-        int neighbor = cp.neighboring_checkpoints[i];
-        int found = find_checkpoint_recursive(pos, neighbor, iterations + 1);
-        if (found != -1)
-            return found;
-    }
-    return -1;
-}
+        int cp0 = find_checkpoint_recursive(p0, start_idx);
+        int cp1 = find_checkpoint_recursive(p1, start_idx);
+        add_cp(cp0);
+        add_cp(cp1);
+        if (cp0 != -1) {
+            const CollisionCheckpoint &cp = checkpoints[cp0];
+            for (int i = 0; i < cp.num_neighboring_checkpoints; ++i)
+                add_cp(cp.neighboring_checkpoints[i]);
+        }
+        if (cp1 != -1 && cp1 != cp0) {
+            const CollisionCheckpoint &cp = checkpoints[cp1];
+            for (int i = 0; i < cp.num_neighboring_checkpoints; ++i)
+                add_cp(cp.neighboring_checkpoints[i]);
+        }
+        const TrackSegment &segment = segments[checkpoints[cp_idx].road_segment];
+        segment.road_shape->get_oriented_transform_at_time(surf0, road_t0);
+        segment.road_shape->get_oriented_transform_at_time(surf1, road_t1);
+        if ((d0 <= 0.0f && d1 <= 0.0f) || (d0 >= 0.0f && d1 >= 0.0f)) {
+            // no crossing of road surface
+        } else {
+            float t = d0 / (d0 - d1);
+            if (t >= 0.0f && t <= 1.0f) {
+                godot::Vector3 hit_point = p0 + ray * t;
+                godot::Vector2 road_t_hit; godot::Vector3 spatial_t_hit;
+                convert_point_to_road(this, cp_idx, hit_point, road_t_hit, spatial_t_hit);
+                godot::Transform3D surf_hit;
+                segment.road_shape->get_oriented_transform_at_time(surf_hit, road_t_hit);
+                godot::Vector3 normal = surf_hit.basis[1];
+                if ((mask & CAST_FLAGS::WANTS_BACKFACE) != 0 || ray.dot(normal) <= 0.0f) {
+                    float dist = t * ray.length();
+                    if (dist < best_t) {
+                        best_t = dist;
+                        out_collision.collided = true;
+                        out_collision.collision_point = hit_point;
+                        out_collision.collision_normal = normal;
+                        out_collision.road_data.cp_idx = cp_idx;
+                        out_collision.road_data.spatial_t = spatial_t_hit;
+                        out_collision.road_data.road_t = road_t_hit;
+                        segment.road_shape->get_oriented_transform_at_time(out_collision.road_data.closest_surface, road_t_hit);
+                        segment.curve_matrix->sample(out_collision.road_data.closest_root, road_t_hit.y);
+                        out_collision.road_data.terrain = 0;
+                        if (mask & CAST_FLAGS::WANTS_TERRAIN) {
+                            for (int i = 0; i < segment.road_shape->num_embeds; ++i) {
+                                RoadEmbed *embed = &segment.road_shape->road_embeds[i];
+                                if (road_t_hit.y > embed->start_offset && road_t_hit.y < embed->end_offset) {
+                                    float et = (road_t_hit.y - embed->start_offset) / (embed->end_offset - embed->start_offset);
+                                    float l = embed->left_border->sample(et);
+                                    float r = embed->right_border->sample(et);
+                                    if (road_t_hit.x < l && road_t_hit.x > r) {
+                                        out_collision.road_data.terrain = embed->embed_type;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (!(mask & CAST_FLAGS::WANTS_RAIL))
+        godot::Transform3D root_t;
+        segment.curve_matrix->sample(root_t, (road_t0.y + road_t1.y) * 0.5f);
+        godot::Basis rbasis = root_t.basis.transposed();
+        const godot::Vector3 left_pos = root_t.origin + rbasis[0];
+        const godot::Vector3 right_pos = root_t.origin - rbasis[0];
+        const godot::Vector3 left_plane_n = -rbasis[0].normalized();
+        const godot::Vector3 right_plane_n = rbasis[0].normalized();
 
-static void convert_point_to_road(const RaceTrack *track, int cp_idx, const godot::Vector3 &point,
-                                  godot::Vector2 &road_t, godot::Vector3 &spatial_t)
-{
-    const CollisionCheckpoint &cp = track->checkpoints[cp_idx];
-    godot::Vector3 p1 = cp.start_plane.project(point);
-    godot::Vector3 p2 = cp.end_plane.project(point);
-    float cp_t = get_closest_t_on_segment(point, p1, p2);
-    godot::Basis basis;
-    basis[0] = cp.orientation_start[0].lerp(cp.orientation_end[0], cp_t).normalized();
-    basis[2] = cp.orientation_start[2].lerp(cp.orientation_end[2], cp_t).normalized();
-    basis[1] = cp.orientation_start[1].lerp(cp.orientation_end[1], cp_t).normalized();
-    godot::Vector3 midpoint = cp.position_start.lerp(cp.position_end, cp_t);
-    godot::Plane sep_x_plane(basis[0], midpoint);
+        struct RailSide { godot::Vector3 pos; godot::Vector3 plane_n; godot::Vector3 rail_n; float height; } sides[2] = {
+            { left_pos, left_plane_n, -surf0.basis[1].cross(surf0.basis[2]), segment.left_rail_height },
+            { right_pos, right_plane_n, surf0.basis[1].cross(surf0.basis[2]), segment.right_rail_height }
+        };
+        for (const auto &side : sides) {
+            float ra = (p0 - side.pos).dot(side.plane_n);
+            float rb = (p1 - side.pos).dot(side.plane_n);
+            if ((ra <= 0.0f && rb <= 0.0f) || (ra >= 0.0f && rb >= 0.0f))
+                continue;
+            float t = ra / (ra - rb);
+            if (t < 0.0f || t > 1.0f)
+                continue;
+            godot::Vector3 hit = p0 + ray * t;
+            godot::Vector2 road_t_hit; godot::Vector3 spatial_t_hit;
+            convert_point_to_road(this, cp_idx, hit, road_t_hit, spatial_t_hit);
+            godot::Transform3D surf_hit;
+            segment.road_shape->get_oriented_transform_at_time(surf_hit, road_t_hit);
+            float vdist = (hit - surf_hit.origin).dot(surf_hit.basis[1]);
+            if (vdist < 0.0f || vdist > side.height)
+                continue;
+            if ((mask & CAST_FLAGS::WANTS_BACKFACE) == 0 && ray.dot(side.rail_n) > 0.0f)
+                continue;
+            float dist = t * ray.length();
+            if (dist < best_t) {
+                best_t = dist;
+                out_collision.collided = true;
+                out_collision.collision_point = hit;
+                out_collision.collision_normal = side.rail_n;
+                out_collision.road_data.cp_idx = cp_idx;
+                out_collision.road_data.spatial_t = spatial_t_hit;
+                out_collision.road_data.road_t = road_t_hit;
+                segment.road_shape->get_oriented_transform_at_time(out_collision.road_data.closest_surface, road_t_hit);
+                segment.curve_matrix->sample(out_collision.road_data.closest_root, road_t_hit.y);
+                out_collision.road_data.terrain = 0;
+            }
     godot::Plane sep_y_plane(basis.get_column(1), midpoint);
     float x_r = lerp(cp.x_radius_start_inv, cp.x_radius_end_inv, cp_t);
     float y_r = lerp(cp.y_radius_start_inv, cp.y_radius_end_inv, cp_t);

--- a/src/track/racetrack.cpp
+++ b/src/track/racetrack.cpp
@@ -2,6 +2,7 @@
 #include "car/physics_car.h" // for CollisionData and RoadData
 #include <cfloat>
 #include <algorithm>
+#include "mxt_core/enums.h"
 
 int RaceTrack::find_checkpoint_recursive(const godot::Vector3 &pos, int cp_index, int iterations) const
 {

--- a/src/track/racetrack.cpp
+++ b/src/track/racetrack.cpp
@@ -1,0 +1,113 @@
+#include "track/racetrack.h"
+#include "car/physics_car.h" // for CollisionData and RoadData
+#include <cfloat>
+#include <algorithm>
+
+int RaceTrack::find_checkpoint_recursive(const godot::Vector3 &pos, int cp_index, int iterations) const
+{
+    if (iterations > 10)
+        return -1;
+    const CollisionCheckpoint &cp = checkpoints[cp_index];
+    if (!cp.end_plane.is_point_over(pos) && cp.start_plane.is_point_over(pos))
+        return cp_index;
+    for (int i = 0; i < cp.num_neighboring_checkpoints; ++i) {
+        int neighbor = cp.neighboring_checkpoints[i];
+        int found = find_checkpoint_recursive(pos, neighbor, iterations + 1);
+        if (found != -1)
+            return found;
+    }
+    return -1;
+}
+
+static void convert_point_to_road(const RaceTrack *track, int cp_idx, const godot::Vector3 &point,
+                                  godot::Vector2 &road_t, godot::Vector3 &spatial_t)
+{
+    const CollisionCheckpoint &cp = track->checkpoints[cp_idx];
+    godot::Vector3 p1 = cp.start_plane.project(point);
+    godot::Vector3 p2 = cp.end_plane.project(point);
+    float cp_t = get_closest_t_on_segment(point, p1, p2);
+    godot::Basis basis;
+    basis[0] = cp.orientation_start[0].lerp(cp.orientation_end[0], cp_t).normalized();
+    basis[2] = cp.orientation_start[2].lerp(cp.orientation_end[2], cp_t).normalized();
+    basis[1] = cp.orientation_start[1].lerp(cp.orientation_end[1], cp_t).normalized();
+    godot::Vector3 midpoint = cp.position_start.lerp(cp.position_end, cp_t);
+    godot::Plane sep_x_plane(basis[0], midpoint);
+    godot::Plane sep_y_plane(basis.get_column(1), midpoint);
+    float x_r = lerp(cp.x_radius_start_inv, cp.x_radius_end_inv, cp_t);
+    float y_r = lerp(cp.y_radius_start_inv, cp.y_radius_end_inv, cp_t);
+    float tx = sep_x_plane.distance_to(point) * x_r;
+    float ty = sep_y_plane.distance_to(point) * y_r;
+    float tz = remap_float(cp_t, 0.0f, 1.0f, cp.t_start, cp.t_end);
+    spatial_t = godot::Vector3(tx, ty, tz);
+    track->segments[cp.road_segment].road_shape->find_t_from_relative_pos(road_t, spatial_t);
+}
+
+void RaceTrack::cast_vs_track(CollisionData &out_collision, const godot::Vector3 &p0, const godot::Vector3 &p1, uint8_t mask, int start_idx)
+{
+    out_collision.collided = false;
+    out_collision.road_data.cp_idx = -1;
+
+    if ((mask & CAST_FLAGS::WANTS_TRACK) == 0)
+        return;
+
+    std::vector<int> checkpoints_to_test;
+    if (start_idx == -1) {
+        checkpoints_to_test = get_viable_checkpoints((p0 + p1) * 0.5f);
+    } else {
+        int cp = find_checkpoint_recursive(p0, start_idx);
+        if (cp == -1)
+            cp = find_checkpoint_recursive(p1, start_idx);
+        if (cp != -1)
+            checkpoints_to_test.push_back(cp);
+    }
+
+    if (checkpoints_to_test.empty())
+        return;
+
+    float best_t = FLT_MAX;
+    godot::Vector3 ray = p1 - p0;
+
+    for (int cp_idx : checkpoints_to_test) {
+        godot::Vector2 road_t0, road_t1;
+        godot::Vector3 spatial_t0, spatial_t1;
+        convert_point_to_road(this, cp_idx, p0, road_t0, spatial_t0);
+        convert_point_to_road(this, cp_idx, p1, road_t1, spatial_t1);
+
+        godot::Transform3D surf0, surf1;
+        segments[checkpoints[cp_idx].road_segment].road_shape->get_oriented_transform_at_time(surf0, road_t0);
+        segments[checkpoints[cp_idx].road_segment].road_shape->get_oriented_transform_at_time(surf1, road_t1);
+        float d0 = (p0 - surf0.origin).dot(surf0.basis[1]);
+        float d1 = (p1 - surf1.origin).dot(surf1.basis[1]);
+
+        if ((d0 > 0.0f && d1 > 0.0f) || (d0 < 0.0f && d1 < 0.0f))
+            continue;
+
+        float t = d0 / (d0 - d1);
+        if (t < 0.0f || t > 1.0f)
+            continue;
+
+        godot::Vector3 hit_point = p0 + ray * t;
+        godot::Vector2 road_t_hit; godot::Vector3 spatial_t_hit;
+        convert_point_to_road(this, cp_idx, hit_point, road_t_hit, spatial_t_hit);
+        godot::Transform3D surf_hit;
+        segments[checkpoints[cp_idx].road_segment].road_shape->get_oriented_transform_at_time(surf_hit, road_t_hit);
+        godot::Vector3 normal = surf_hit.basis[1];
+        if ((mask & CAST_FLAGS::WANTS_BACKFACE) == 0 && ray.dot(normal) > 0.0f)
+            continue;
+
+        float dist = t * ray.length();
+        if (dist < best_t) {
+            best_t = dist;
+            out_collision.collided = true;
+            out_collision.collision_point = hit_point;
+            out_collision.collision_normal = normal;
+            out_collision.road_data.terrain = 0;
+            out_collision.road_data.cp_idx = cp_idx;
+            out_collision.road_data.spatial_t = spatial_t_hit;
+            out_collision.road_data.road_t = road_t_hit;
+            segments[checkpoints[cp_idx].road_segment].road_shape->get_oriented_transform_at_time(out_collision.road_data.closest_surface, road_t_hit);
+            segments[checkpoints[cp_idx].road_segment].curve_matrix->sample(out_collision.road_data.closest_root, road_t_hit.y);
+        }
+    }
+}
+

--- a/src/track/racetrack.cpp
+++ b/src/track/racetrack.cpp
@@ -2,10 +2,67 @@
 #include "car/physics_car.h" // for CollisionData and RoadData
 #include <cfloat>
 #include <algorithm>
-#include <cmath>
-    cp_t = fminf(fmaxf(cp_t, 0.0f), 1.0f);
-    tx = fminf(fmaxf(tx, -1.0f), 1.0f);
-    ty = fminf(fmaxf(ty, -1.0f), 1.0f);
+#include "mxt_core/enums.h"
+
+int RaceTrack::find_checkpoint_recursive(const godot::Vector3 &pos, int cp_index, int iterations) const
+{
+    if (iterations > 10)
+        return -1;
+    const CollisionCheckpoint &cp = checkpoints[cp_index];
+    if (!cp.end_plane.is_point_over(pos) && cp.start_plane.is_point_over(pos))
+        return cp_index;
+    for (int i = 0; i < cp.num_neighboring_checkpoints; ++i) {
+        int neighbor = cp.neighboring_checkpoints[i];
+        int found = find_checkpoint_recursive(pos, neighbor, iterations + 1);
+        if (found != -1)
+            return found;
+    }
+    return -1;
+}
+
+static void convert_point_to_road(const RaceTrack *track, int cp_idx, const godot::Vector3 &point,
+                                  godot::Vector2 &road_t, godot::Vector3 &spatial_t, float *out_cp_t = nullptr)
+{
+    const CollisionCheckpoint &cp = track->checkpoints[cp_idx];
+    godot::Vector3 p1 = cp.start_plane.project(point);
+    godot::Vector3 p2 = cp.end_plane.project(point);
+    float cp_t = get_closest_t_on_segment(point, p1, p2);
+    if (out_cp_t)
+        *out_cp_t = cp_t;
+    float cp_t_clamped = fminf(fmaxf(cp_t, 0.0f), 1.0f);
+    godot::Basis basis;
+    basis[0] = cp.orientation_start[0].lerp(cp.orientation_end[0], cp_t_clamped).normalized();
+    basis[2] = cp.orientation_start[2].lerp(cp.orientation_end[2], cp_t_clamped).normalized();
+    basis[1] = cp.orientation_start[1].lerp(cp.orientation_end[1], cp_t_clamped).normalized();
+    godot::Vector3 midpoint = cp.position_start.lerp(cp.position_end, cp_t_clamped);
+    godot::Plane sep_x_plane(basis[0], midpoint);
+    godot::Plane sep_y_plane(basis.get_column(1), midpoint);
+    float x_r = lerp(cp.x_radius_start_inv, cp.x_radius_end_inv, cp_t_clamped);
+    float y_r = lerp(cp.y_radius_start_inv, cp.y_radius_end_inv, cp_t_clamped);
+    float tx = sep_x_plane.distance_to(point) * x_r;
+    float ty = sep_y_plane.distance_to(point) * y_r;
+    float tz = remap_float(cp_t_clamped, 0.0f, 1.0f, cp.t_start, cp.t_end);
+    spatial_t = godot::Vector3(tx, ty, tz);
+    track->segments[cp.road_segment].road_shape->find_t_from_relative_pos(road_t, spatial_t);
+}
+
+struct CastParams {
+    RaceTrack *track;
+    uint8_t mask;
+};
+
+static void cast_segment(const CastParams &params, CollisionData &out_collision,
+                         const godot::Vector3 &p0, const godot::Vector3 &p1,
+                         int start_idx)
+{
+    out_collision.collided = false;
+    out_collision.road_data.cp_idx = -1;
+
+    if ((params.mask & CAST_FLAGS::WANTS_TRACK) == 0)
+        return;
+
+    RaceTrack *track = params.track;
+    std::vector<int> checkpoints_to_test;
     auto add_cp = [&checkpoints_to_test](int idx) {
         if (idx < 0)
             return;
@@ -13,35 +70,50 @@
             checkpoints_to_test.push_back(idx);
     };
 
-        int cp0 = find_checkpoint_recursive(p0, start_idx);
-        int cp1 = find_checkpoint_recursive(p1, start_idx);
+    if (start_idx == -1) {
+        checkpoints_to_test = track->get_viable_checkpoints(p0);
+    } else {
+        int cp0 = track->find_checkpoint_recursive(p0, start_idx);
         add_cp(cp0);
-        add_cp(cp1);
-        if (cp0 != -1) {
-            const CollisionCheckpoint &cp = checkpoints[cp0];
-            for (int i = 0; i < cp.num_neighboring_checkpoints; ++i)
-                add_cp(cp.neighboring_checkpoints[i]);
-        }
-        if (cp1 != -1 && cp1 != cp0) {
-            const CollisionCheckpoint &cp = checkpoints[cp1];
-            for (int i = 0; i < cp.num_neighboring_checkpoints; ++i)
-                add_cp(cp.neighboring_checkpoints[i]);
-        }
-        const TrackSegment &segment = segments[checkpoints[cp_idx].road_segment];
+    }
+
+    if (checkpoints_to_test.empty())
+        return;
+
+    float best_t = FLT_MAX;
+    godot::Vector3 ray = p1 - p0;
+
+    for (int cp_idx : checkpoints_to_test) {
+        const TrackSegment &segment = track->segments[track->checkpoints[cp_idx].road_segment];
+        godot::Vector2 road_t0_raw, road_t1_raw;
+        godot::Vector3 spatial_t0, spatial_t1;
+        convert_point_to_road(track, cp_idx, p0, road_t0_raw, spatial_t0);
+        convert_point_to_road(track, cp_idx, p1, road_t1_raw, spatial_t1);
+
+        godot::Vector2 road_t0 = road_t0_raw;
+        godot::Vector2 road_t1 = road_t1_raw;
+        road_t0.x = fminf(fmaxf(road_t0.x, -1.0f), 1.0f);
+        road_t1.x = fminf(fmaxf(road_t1.x, -1.0f), 1.0f);
+
+        godot::Transform3D surf0, surf1;
         segment.road_shape->get_oriented_transform_at_time(surf0, road_t0);
         segment.road_shape->get_oriented_transform_at_time(surf1, road_t1);
+        float d0 = (p0 - surf0.origin).dot(surf0.basis[1]);
+        float d1 = (p1 - surf1.origin).dot(surf1.basis[1]);
+
         if ((d0 <= 0.0f && d1 <= 0.0f) || (d0 >= 0.0f && d1 >= 0.0f)) {
-            // no crossing of road surface
         } else {
             float t = d0 / (d0 - d1);
             if (t >= 0.0f && t <= 1.0f) {
                 godot::Vector3 hit_point = p0 + ray * t;
-                godot::Vector2 road_t_hit; godot::Vector3 spatial_t_hit;
-                convert_point_to_road(this, cp_idx, hit_point, road_t_hit, spatial_t_hit);
+                godot::Vector2 road_t_hit_raw; godot::Vector3 spatial_t_hit;
+                convert_point_to_road(track, cp_idx, hit_point, road_t_hit_raw, spatial_t_hit);
+                godot::Vector2 road_t_hit = road_t_hit_raw;
+                road_t_hit.x = fminf(fmaxf(road_t_hit.x, -1.0f), 1.0f);
                 godot::Transform3D surf_hit;
                 segment.road_shape->get_oriented_transform_at_time(surf_hit, road_t_hit);
                 godot::Vector3 normal = surf_hit.basis[1];
-                if ((mask & CAST_FLAGS::WANTS_BACKFACE) != 0 || ray.dot(normal) <= 0.0f) {
+                if ((params.mask & CAST_FLAGS::WANTS_BACKFACE) != 0 || ray.dot(normal) <= 0.0f) {
                     float dist = t * ray.length();
                     if (dist < best_t) {
                         best_t = dist;
@@ -50,18 +122,18 @@
                         out_collision.collision_normal = normal;
                         out_collision.road_data.cp_idx = cp_idx;
                         out_collision.road_data.spatial_t = spatial_t_hit;
-                        out_collision.road_data.road_t = road_t_hit;
+                        out_collision.road_data.road_t = road_t_hit_raw;
                         segment.road_shape->get_oriented_transform_at_time(out_collision.road_data.closest_surface, road_t_hit);
                         segment.curve_matrix->sample(out_collision.road_data.closest_root, road_t_hit.y);
                         out_collision.road_data.terrain = 0;
-                        if (mask & CAST_FLAGS::WANTS_TERRAIN) {
+                        if (params.mask & CAST_FLAGS::WANTS_TERRAIN) {
                             for (int i = 0; i < segment.road_shape->num_embeds; ++i) {
                                 RoadEmbed *embed = &segment.road_shape->road_embeds[i];
-                                if (road_t_hit.y > embed->start_offset && road_t_hit.y < embed->end_offset) {
-                                    float et = (road_t_hit.y - embed->start_offset) / (embed->end_offset - embed->start_offset);
+                                if (road_t_hit_raw.y > embed->start_offset && road_t_hit_raw.y < embed->end_offset) {
+                                    float et = (road_t_hit_raw.y - embed->start_offset) / (embed->end_offset - embed->start_offset);
                                     float l = embed->left_border->sample(et);
                                     float r = embed->right_border->sample(et);
-                                    if (road_t_hit.x < l && road_t_hit.x > r) {
+                                    if (road_t_hit_raw.x < l && road_t_hit_raw.x > r) {
                                         out_collision.road_data.terrain = embed->embed_type;
                                         break;
                                     }
@@ -72,9 +144,12 @@
                 }
             }
         }
-        if (!(mask & CAST_FLAGS::WANTS_RAIL))
+
+        if (!(params.mask & CAST_FLAGS::WANTS_RAIL))
+            continue;
+
         godot::Transform3D root_t;
-        segment.curve_matrix->sample(root_t, (road_t0.y + road_t1.y) * 0.5f);
+        segment.curve_matrix->sample(root_t, (road_t0_raw.y + road_t1_raw.y) * 0.5f);
         godot::Basis rbasis = root_t.basis.transposed();
         const godot::Vector3 left_pos = root_t.origin + rbasis[0];
         const godot::Vector3 right_pos = root_t.origin - rbasis[0];
@@ -85,6 +160,7 @@
             { left_pos, left_plane_n, -surf0.basis[1].cross(surf0.basis[2]), segment.left_rail_height },
             { right_pos, right_plane_n, surf0.basis[1].cross(surf0.basis[2]), segment.right_rail_height }
         };
+
         for (const auto &side : sides) {
             float ra = (p0 - side.pos).dot(side.plane_n);
             float rb = (p1 - side.pos).dot(side.plane_n);
@@ -94,14 +170,16 @@
             if (t < 0.0f || t > 1.0f)
                 continue;
             godot::Vector3 hit = p0 + ray * t;
-            godot::Vector2 road_t_hit; godot::Vector3 spatial_t_hit;
-            convert_point_to_road(this, cp_idx, hit, road_t_hit, spatial_t_hit);
+            godot::Vector2 road_t_hit_raw; godot::Vector3 spatial_t_hit;
+            convert_point_to_road(track, cp_idx, hit, road_t_hit_raw, spatial_t_hit);
+            godot::Vector2 road_t_hit = road_t_hit_raw;
+            road_t_hit.x = fminf(fmaxf(road_t_hit.x, -1.0f), 1.0f);
             godot::Transform3D surf_hit;
             segment.road_shape->get_oriented_transform_at_time(surf_hit, road_t_hit);
             float vdist = (hit - surf_hit.origin).dot(surf_hit.basis[1]);
             if (vdist < 0.0f || vdist > side.height)
                 continue;
-            if ((mask & CAST_FLAGS::WANTS_BACKFACE) == 0 && ray.dot(side.rail_n) > 0.0f)
+            if ((params.mask & CAST_FLAGS::WANTS_BACKFACE) == 0 && ray.dot(side.rail_n) > 0.0f)
                 continue;
             float dist = t * ray.length();
             if (dist < best_t) {
@@ -111,19 +189,13 @@
                 out_collision.collision_normal = side.rail_n;
                 out_collision.road_data.cp_idx = cp_idx;
                 out_collision.road_data.spatial_t = spatial_t_hit;
-                out_collision.road_data.road_t = road_t_hit;
+                out_collision.road_data.road_t = road_t_hit_raw;
                 segment.road_shape->get_oriented_transform_at_time(out_collision.road_data.closest_surface, road_t_hit);
                 segment.curve_matrix->sample(out_collision.road_data.closest_root, road_t_hit.y);
                 out_collision.road_data.terrain = 0;
             }
-    godot::Plane sep_y_plane(basis.get_column(1), midpoint);
-    float x_r = lerp(cp.x_radius_start_inv, cp.x_radius_end_inv, cp_t);
-    float y_r = lerp(cp.y_radius_start_inv, cp.y_radius_end_inv, cp_t);
-    float tx = sep_x_plane.distance_to(point) * x_r;
-    float ty = sep_y_plane.distance_to(point) * y_r;
-    float tz = remap_float(cp_t, 0.0f, 1.0f, cp.t_start, cp.t_end);
-    spatial_t = godot::Vector3(tx, ty, tz);
-    track->segments[cp.road_segment].road_shape->find_t_from_relative_pos(road_t, spatial_t);
+        }
+    }
 }
 
 void RaceTrack::cast_vs_track(CollisionData &out_collision, const godot::Vector3 &p0, const godot::Vector3 &p1, uint8_t mask, int start_idx)
@@ -134,64 +206,40 @@ void RaceTrack::cast_vs_track(CollisionData &out_collision, const godot::Vector3
     if ((mask & CAST_FLAGS::WANTS_TRACK) == 0)
         return;
 
-    std::vector<int> checkpoints_to_test;
-    if (start_idx == -1) {
-        checkpoints_to_test = get_viable_checkpoints((p0 + p1) * 0.5f);
-    } else {
-        int cp = find_checkpoint_recursive(p0, start_idx);
-        if (cp == -1)
-            cp = find_checkpoint_recursive(p1, start_idx);
-        if (cp != -1)
-            checkpoints_to_test.push_back(cp);
-    }
+    const float step_len = 0.5f;
+    const float epsilon = 0.05f;
 
-    if (checkpoints_to_test.empty())
-        return;
-
-    float best_t = FLT_MAX;
     godot::Vector3 ray = p1 - p0;
+    float total_len = ray.length();
+    if (total_len == 0.0f)
+        return;
+    godot::Vector3 dir = ray / total_len;
 
-    for (int cp_idx : checkpoints_to_test) {
-        godot::Vector2 road_t0, road_t1;
-        godot::Vector3 spatial_t0, spatial_t1;
-        convert_point_to_road(this, cp_idx, p0, road_t0, spatial_t0);
-        convert_point_to_road(this, cp_idx, p1, road_t1, spatial_t1);
+    CastParams params{ this, mask };
 
-        godot::Transform3D surf0, surf1;
-        segments[checkpoints[cp_idx].road_segment].road_shape->get_oriented_transform_at_time(surf0, road_t0);
-        segments[checkpoints[cp_idx].road_segment].road_shape->get_oriented_transform_at_time(surf1, road_t1);
-        float d0 = (p0 - surf0.origin).dot(surf0.basis[1]);
-        float d1 = (p1 - surf1.origin).dot(surf1.basis[1]);
+    godot::Vector3 cur = p0;
+    float travelled = 0.0f;
+    int cp_idx = start_idx;
 
-        if ((d0 > 0.0f && d1 > 0.0f) || (d0 < 0.0f && d1 < 0.0f))
-            continue;
+    if (cp_idx != -1)
+        cp_idx = find_checkpoint_recursive(cur, cp_idx);
 
-        float t = d0 / (d0 - d1);
-        if (t < 0.0f || t > 1.0f)
-            continue;
-
-        godot::Vector3 hit_point = p0 + ray * t;
-        godot::Vector2 road_t_hit; godot::Vector3 spatial_t_hit;
-        convert_point_to_road(this, cp_idx, hit_point, road_t_hit, spatial_t_hit);
-        godot::Transform3D surf_hit;
-        segments[checkpoints[cp_idx].road_segment].road_shape->get_oriented_transform_at_time(surf_hit, road_t_hit);
-        godot::Vector3 normal = surf_hit.basis[1];
-        if ((mask & CAST_FLAGS::WANTS_BACKFACE) == 0 && ray.dot(normal) > 0.0f)
-            continue;
-
-        float dist = t * ray.length();
-        if (dist < best_t) {
-            best_t = dist;
-            out_collision.collided = true;
-            out_collision.collision_point = hit_point;
-            out_collision.collision_normal = normal;
-            out_collision.road_data.terrain = 0;
-            out_collision.road_data.cp_idx = cp_idx;
-            out_collision.road_data.spatial_t = spatial_t_hit;
-            out_collision.road_data.road_t = road_t_hit;
-            segments[checkpoints[cp_idx].road_segment].road_shape->get_oriented_transform_at_time(out_collision.road_data.closest_surface, road_t_hit);
-            segments[checkpoints[cp_idx].road_segment].curve_matrix->sample(out_collision.road_data.closest_root, road_t_hit.y);
+    while (travelled < total_len) {
+        float seg = fminf(step_len, total_len - travelled);
+        godot::Vector3 next = cur + dir * seg;
+        CollisionData hit;
+        cast_segment(params, hit, cur, next, cp_idx);
+        if (hit.collided) {
+            godot::Vector3 back = hit.collision_point - dir * epsilon;
+            cast_segment(params, hit, back, hit.collision_point + dir * epsilon * 2, hit.road_data.cp_idx);
+            if (hit.collided) {
+                out_collision = hit;
+                return;
+            }
         }
+        cur = next;
+        travelled += seg;
+        if (cp_idx != -1)
+            cp_idx = find_checkpoint_recursive(cur, cp_idx);
     }
 }
-

--- a/src/track/racetrack.h
+++ b/src/track/racetrack.h
@@ -5,16 +5,20 @@
 #include "mxt_core/math_utils.h"
 #include <vector>
 
+struct CollisionData;
+
 class RaceTrack
 {
 public:
-	int num_segments;
-	int num_checkpoints;
-	TrackSegment* segments;
-	CollisionCheckpoint* checkpoints;
-	std::vector<int> get_viable_checkpoints(godot::Vector3 in_point)
-	{
-		std::vector<int> return_checkpoints;
+        int num_segments;
+        int num_checkpoints;
+        TrackSegment* segments;
+        CollisionCheckpoint* checkpoints;
+        int find_checkpoint_recursive(const godot::Vector3 &pos, int cp_index, int iterations = 0) const;
+        void cast_vs_track(CollisionData &out_collision, const godot::Vector3 &p0, const godot::Vector3 &p1, uint8_t mask, int start_idx = 0);
+        std::vector<int> get_viable_checkpoints(godot::Vector3 in_point)
+        {
+                std::vector<int> return_checkpoints;
 		return_checkpoints.reserve(16);
 
 		// todo: implement a broad phase that can quickly cut out large amounts of checkpoints


### PR DESCRIPTION
## Summary
- extend `RaceTrack` with `cast_vs_track` and helper
- implement raycasting against road surfaces

## Testing
- `scons -j2` *(fails: Missing godot-cpp)*

------
https://chatgpt.com/codex/tasks/task_e_684b63ead910832d8eb641548598e939