### PR TITLE
Port collision response

### DIFF
--- a/src/car/physics_car.h
+++ b/src/car/physics_car.h
@@ -202,9 +202,10 @@ public:
 	void apply_torque_from_force(const godot::Vector3& p_local_offset, const godot::Vector3& wf_world_force);
 	void simulate_machine_motion();
 	int update_machine_corners();
-	void create_machine_visual_transform();
-	void handle_machine_collision_response();
-	void align_machine_y_with_track_normal_immediate();
-	void post_tick();
-	void tick(const PlayerInput& frame_input /* , uint64_t current_game_tick, other game state if needed */);
+        void create_machine_visual_transform();
+        void handle_machine_collision_response();
+        void align_machine_y_with_track_normal_immediate();
+        void handle_checkpoints();
+        void post_tick();
+        void tick(const PlayerInput& frame_input /* , uint64_t current_game_tick, other game state if needed */);
 };


### PR DESCRIPTION
## Summary
- implement `handle_machine_collision_response` for `PhysicsCar`
- add helper `set_vec3_length`
- port `align_machine_y_with_track_normal_immediate`
- port `post_tick` and `tick`
- port `handle_checkpoints`

## Testing
- `scons -j4` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ccdfe9da0832da8576ca5f4bace06