### PR TITLE
Add shape type property for RoadShape

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,28 +189,33 @@ void GameSim::instantiate_gamesim(StreamPeerBuffer* lvldat_buf)
 
 		// what road shape? //
 
-		if (road_type == 0)
-		{
-			current_track->segments[seg].road_shape = level_data.allocate_class<RoadShape>();
-		}
-		else if (road_type == 1)
-		{
-			current_track->segments[seg].road_shape = level_data.allocate_class<RoadShapeCylinder>();
-		}
-		else if (road_type == 2)
-		{
-			current_track->segments[seg].road_shape = level_data.allocate_class<RoadShapeCylinderOpen>();
-			current_track->segments[seg].road_shape->openness = level_data.allocate_curve_from_buffer(lvldat_buf);
-		}
-		else if (road_type == 3)
-		{
-			current_track->segments[seg].road_shape = level_data.allocate_class<RoadShapePipe>();
-		}
-		else if (road_type == 4)
-		{
-			current_track->segments[seg].road_shape = level_data.allocate_class<RoadShapePipeOpen>();
-			current_track->segments[seg].road_shape->openness = level_data.allocate_curve_from_buffer(lvldat_buf);
-		}
+                if (road_type == 0)
+                {
+                        current_track->segments[seg].road_shape = level_data.allocate_class<RoadShape>();
+                        current_track->segments[seg].road_shape->shape_type = ROAD_SHAPE_TYPE::ROAD_SHAPE_FLAT;
+                }
+                else if (road_type == 1)
+                {
+                        current_track->segments[seg].road_shape = level_data.allocate_class<RoadShapeCylinder>();
+                        current_track->segments[seg].road_shape->shape_type = ROAD_SHAPE_TYPE::ROAD_SHAPE_CYLINDER;
+                }
+                else if (road_type == 2)
+                {
+                        current_track->segments[seg].road_shape = level_data.allocate_class<RoadShapeCylinderOpen>();
+                        current_track->segments[seg].road_shape->openness = level_data.allocate_curve_from_buffer(lvldat_buf);
+                        current_track->segments[seg].road_shape->shape_type = ROAD_SHAPE_TYPE::ROAD_SHAPE_CYLINDER_OPEN;
+                }
+                else if (road_type == 3)
+                {
+                        current_track->segments[seg].road_shape = level_data.allocate_class<RoadShapePipe>();
+                        current_track->segments[seg].road_shape->shape_type = ROAD_SHAPE_TYPE::ROAD_SHAPE_PIPE;
+                }
+                else if (road_type == 4)
+                {
+                        current_track->segments[seg].road_shape = level_data.allocate_class<RoadShapePipeOpen>();
+                        current_track->segments[seg].road_shape->openness = level_data.allocate_curve_from_buffer(lvldat_buf);
+                        current_track->segments[seg].road_shape->shape_type = ROAD_SHAPE_TYPE::ROAD_SHAPE_PIPE_OPEN;
+                }
 
 		// road modulations //
 

--- a/src/mxt_core/enums.h
+++ b/src/mxt_core/enums.h
@@ -79,10 +79,20 @@ namespace CAST_FLAGS {
 }
 
 namespace DIP_SWITCH {
-	enum FLAGS {
-		DIP_DRAW_RAYCASTS = 0x1,
-		DIP_DRAW_CHECKPOINTS = 0x2,
-		DIP_DRAW_SEGMENT_SURF = 0x4,
-		DIP_DRAW_TILT_CORNER_DATA = 0x8,
-	};
+        enum FLAGS {
+                DIP_DRAW_RAYCASTS = 0x1,
+                DIP_DRAW_CHECKPOINTS = 0x2,
+                DIP_DRAW_SEGMENT_SURF = 0x4,
+                DIP_DRAW_TILT_CORNER_DATA = 0x8,
+        };
+}
+
+namespace ROAD_SHAPE_TYPE {
+        enum TYPE {
+                ROAD_SHAPE_FLAT = 0x0,
+                ROAD_SHAPE_CYLINDER = 0x1,
+                ROAD_SHAPE_CYLINDER_OPEN = 0x2,
+                ROAD_SHAPE_PIPE = 0x3,
+                ROAD_SHAPE_PIPE_OPEN = 0x4
+        };
 }

--- a/src/track/track_segment.h
+++ b/src/track/track_segment.h
@@ -3,6 +3,7 @@
 #include "mxt_core/curve.h"
 #include "track/road_modulation.h"
 #include "track/road_embed.h"
+#include "mxt_core/enums.h"
 
 class RoadShape;
 
@@ -19,9 +20,10 @@ public:
 class RoadShape
 {
 public:
-	int num_modulations;
-	int num_embeds;
-	TrackSegment* owning_segment;
+        int num_modulations;
+        int num_embeds;
+        int shape_type;
+        TrackSegment* owning_segment;
 	RoadModulation* road_modulations;
 	RoadEmbed* road_embeds;
 	Curve* openness;


### PR DESCRIPTION
## Summary
- define `ROAD_SHAPE_TYPE` enum for the five road shapes
- add `shape_type` member to `RoadShape`
- set the road shape type when building track segments

## Testing
- `scons -Q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509a1162b8832d9872126f4578e467