### PR TITLE
Add track selection menu

### DIFF
--- a/mxto/main.gd
+++ b/mxto/main.gd
@@ -1,23 +1,71 @@
 extends Node
 
 @onready var game_sim: GameSim = $GameSim
-@onready var button: Button = $Control/Button
+@onready var start_button: Button = $Control/StartButton
+@onready var track_selector: OptionButton = $Control/TrackSelector
 @onready var car_node_container: CarNodeContainer = $GameWorld/CarNodeContainer
 @onready var cam: Camera3D = $GameWorld/Camera3D2
 
-func _on_button_pressed() -> void:
-	car_node_container.instantiate_cars()
-	var level_buffer := StreamPeerBuffer.new()
-	var test_level := FileAccess.get_file_as_bytes("res://test/cylinder_test/cylinder_test.mxt_track")
-	level_buffer.data_array = test_level
-	game_sim.car_node_container = car_node_container
-	game_sim.instantiate_gamesim(level_buffer)
+var tracks: Array = []
+
+func _ready() -> void:
+       _load_tracks()
+
+func _load_tracks() -> void:
+       tracks.clear()
+       track_selector.clear()
+       _scan_dir("res://track")
+       for t in tracks:
+               track_selector.add_item(t["name"])
+       if tracks.size() > 0:
+               track_selector.selected = 0
+
+func _scan_dir(path: String) -> void:
+       var dir := DirAccess.open(path)
+       if dir == null:
+               return
+       dir.list_dir_begin()
+       var file := dir.get_next()
+       while file != "":
+               if dir.current_is_dir() and !file.begins_with("."):
+                       _scan_dir(path + "/" + file)
+               elif file.get_extension() == "json":
+                       var json_path := path + "/" + file
+                       var mxt_path := json_path.get_basename() + ".mxt_track"
+                       if FileAccess.file_exists(mxt_path):
+                               var json_data := FileAccess.get_file_as_string(json_path)
+                               var parsed := JSON.parse_string(json_data)
+                               if typeof(parsed) == TYPE_DICTIONARY and parsed.has("name"):
+                                       tracks.append({"name": parsed["name"], "mxt": mxt_path})
+               file = dir.get_next()
+       dir.list_dir_end()
+
+func _on_start_button_pressed() -> void:
+       if track_selector.selected < 0 or track_selector.selected >= tracks.size():
+               return
+       var info : Dictionary = tracks[track_selector.selected]
+       car_node_container.instantiate_cars()
+       var level_buffer := StreamPeerBuffer.new()
+       level_buffer.data_array = FileAccess.get_file_as_bytes(info["mxt"])
+       game_sim.car_node_container = car_node_container
+       game_sim.instantiate_gamesim(level_buffer)
+       $Control.visible = false
 
 func _physics_process(delta: float) -> void:
-	DebugDraw3D.scoped_config().set_no_depth_test(true)
-	if game_sim.sim_started:
-		game_sim.tick_gamesim()
-		game_sim.render_gamesim()
+       DebugDraw3D.scoped_config().set_no_depth_test(true)
+       if game_sim.sim_started:
+               game_sim.tick_gamesim()
+               game_sim.render_gamesim()
+
+func _unhandled_input(event: InputEvent) -> void:
+       if game_sim.sim_started and event.is_action_pressed("ui_cancel"):
+               _return_to_menu()
+
+func _return_to_menu() -> void:
+       game_sim.destroy_gamesim()
+       for child in car_node_container.get_children():
+               child.queue_free()
+       $Control.visible = true
 
 func _process(delta: float) -> void:
 	pass

--- a/mxto/main.tscn
+++ b/mxto/main.tscn
@@ -31,7 +31,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="Button" type="Button" parent="Control"]
+[node name="StartButton" type="Button" parent="Control"]
 layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
@@ -39,7 +39,17 @@ anchor_right = 1.0
 offset_left = -230.0
 offset_bottom = 31.0
 grow_horizontal = 0
-text = "Instantiate Game Simulation"
+text = "Start"
+
+[node name="TrackSelector" type="OptionButton" parent="Control"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -150.0
+offset_right = 150.0
+offset_top = -40.0
+offset_bottom = -10.0
 
 [node name="GameWorld" type="Node3D" parent="."]
 
@@ -64,4 +74,4 @@ transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 
 mesh = ExtResource("4_1bvp3")
 skeleton = NodePath("")
 
-[connection signal="pressed" from="Control/Button" to="." method="_on_button_pressed"]
+[connection signal="pressed" from="Control/StartButton" to="." method="_on_start_button_pressed"]


### PR DESCRIPTION
## Summary
- add OptionButton-based track menu for Godot
- load track metadata from `res://track` directories
- spawn GameSim with chosen track
- allow returning to the menu with `ESC`

## Testing
- `godot --version` *(fails: command not found)*
- `scons --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685369ffcc90832d803354a3e0200e5a