### PR TITLE
Add spatial hashing voxel grid for checkpoints

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -361,8 +361,27 @@ void GameSim::instantiate_gamesim(StreamPeerBuffer* lvldat_buf)
 				latest_sample_pos = new_sample_pos;
 			}
 		}
-		current_track->segments[seg].segment_length = total_distance;
-	}
+                current_track->segments[seg].segment_length = total_distance;
+        }
+
+// calculate track bounds
+bool bounds_set = false;
+for (int seg = 0; seg < current_track->num_segments; ++seg) {
+for (int x = 0; x < 16; x++) {
+for (int y = 0; y < 32; y++) {
+godot::Vector2 use_t(float(x) / 15.0f, float(y) / 31.0f);
+godot::Vector3 use_pos;
+current_track->segments[seg].road_shape->get_position_at_time(use_pos, use_t);
+if (!bounds_set) {
+current_track->bounds.position = use_pos;
+current_track->bounds.size = godot::Vector3();
+bounds_set = true;
+}
+current_track->bounds.expand_to(use_pos);
+}
+}
+}
+current_track->build_voxel_grid();
 	gamestate_data.instantiate(1024 * 1024);
 	int state_capacity = gamestate_data.get_capacity();
 		for (int i = 0; i < STATE_BUFFER_LEN; i++)

--- a/src/track/racetrack.h
+++ b/src/track/racetrack.h
@@ -4,78 +4,76 @@
 #include "track/collision_checkpoint.h"
 #include "mxt_core/math_utils.h"
 #include <vector>
+#include "godot_cpp/variant/vector3.hpp"
+#include "godot_cpp/variant/aabb.hpp"
 
 struct CollisionData;
 
 class RaceTrack
 {
 public:
-        int num_segments;
-        int num_checkpoints;
-        TrackSegment* segments;
-        CollisionCheckpoint* checkpoints;
+int num_segments;
+int num_checkpoints;
+TrackSegment* segments;
+CollisionCheckpoint* checkpoints;
+godot::AABB bounds;
+float voxel_size = 100.0f;
+godot::Vector3 grid_origin;
+int grid_dim_x = 0;
+int grid_dim_y = 0;
+int grid_dim_z = 0;
+std::vector<std::vector<int>> voxel_grid;
+
+void build_voxel_grid();
+int get_voxel_index(const godot::Vector3 &p) const;
         int find_checkpoint_recursive(const godot::Vector3 &pos, int cp_index, int iterations = 0) const;
         void cast_vs_track(CollisionData &out_collision, const godot::Vector3 &p0, const godot::Vector3 &p1, uint8_t mask, int start_idx = -1, bool oriented = true);
         void cast_vs_track_fast(CollisionData &out_collision, const godot::Vector3 &p0, const godot::Vector3 &p1, uint8_t mask, int start_idx = -1, bool oriented = false);
-        void get_road_surface(int cp_idx, const godot::Vector3 &point, godot::Vector2 &road_t, godot::Vector3 &spatial_t, godot::Transform3D &out_transform, bool oriented = true);
-        std::vector<int> get_viable_checkpoints(godot::Vector3 in_point)
-        {
-                std::vector<int> return_checkpoints;
-		return_checkpoints.reserve(16);
+void get_road_surface(int cp_idx, const godot::Vector3 &point, godot::Vector2 &road_t, godot::Vector3 &spatial_t, godot::Transform3D &out_transform, bool oriented = true);
+std::vector<int> get_viable_checkpoints(godot::Vector3 in_point)
+{
+std::vector<int> return_checkpoints;
+return_checkpoints.reserve(16);
 
-		// todo: implement a broad phase that can quickly cut out large amounts of checkpoints
-		// which do not need testing; BVH, perhaps? at very minimum we can generate an AABB
-		// for each track segment and compare against those AABBs first, and ignore
-		// checkpoints for segments we can't possibly be interacting with
+int vox_idx = get_voxel_index(in_point);
+if (vox_idx == -1)
+return return_checkpoints;
 
-		for (int i = 0; i < num_checkpoints; i++)
-		{
-			if (!checkpoints[i].start_plane.is_point_over(in_point))
-			{
-				continue;
-			}
-			if (checkpoints[i].end_plane.is_point_over(in_point))
-			{
-				continue;
-			}
-			godot::Vector3 avg_pos = (checkpoints[i].position_start + checkpoints[i].position_end) * 0.5f;
-			float max_x_radius = fmaxf(checkpoints[i].x_radius_start, checkpoints[i].x_radius_end);
-			float max_y_radius = fmaxf(checkpoints[i].y_radius_start, checkpoints[i].y_radius_end);
-			float max_total_radius = fmaxf(max_x_radius, max_y_radius);
-			float radius = (checkpoints[i].position_end - checkpoints[i].position_start).length_squared() + max_total_radius * max_total_radius;
-			if (in_point.distance_squared_to(avg_pos) < radius)
-			{
-				return_checkpoints.push_back(i);
-			}
-		}
-		return return_checkpoints;
-	}
-	int get_best_checkpoint(godot::Vector3 in_point) const
-        {
-                std::vector<int> candidates;
-		candidates.reserve(16);
+const std::vector<int> &cell = voxel_grid[vox_idx];
+for (int i : cell) {
+if (!checkpoints[i].start_plane.is_point_over(in_point))
+continue;
+if (checkpoints[i].end_plane.is_point_over(in_point))
+continue;
+godot::Vector3 avg_pos = (checkpoints[i].position_start + checkpoints[i].position_end) * 0.5f;
+float max_x_radius = fmaxf(checkpoints[i].x_radius_start, checkpoints[i].x_radius_end);
+float max_y_radius = fmaxf(checkpoints[i].y_radius_start, checkpoints[i].y_radius_end);
+float max_total_radius = fmaxf(max_x_radius, max_y_radius);
+float radius = (checkpoints[i].position_end - checkpoints[i].position_start).length_squared() + max_total_radius * max_total_radius;
+if (in_point.distance_squared_to(avg_pos) < radius)
+return_checkpoints.push_back(i);
+}
+return return_checkpoints;
+}
+int get_best_checkpoint(godot::Vector3 in_point) const
+{
+std::vector<int> candidates;
+candidates.reserve(16);
 
-		// todo: implement a broad phase that can quickly cut out large amounts of checkpoints
-		// which do not need testing; BVH, perhaps? at very minimum we can generate an AABB
-		// for each track segment and compare against those AABBs first, and ignore
-		// checkpoints for segments we can't possibly be interacting with
-
-		for (int i = 0; i < num_checkpoints; i++)
-		{
-			if (!checkpoints[i].start_plane.is_point_over(in_point))
-			{
-				continue;
-			}
-			if (checkpoints[i].end_plane.is_point_over(in_point))
-			{
-				continue;
-			}
-			candidates.push_back(i);
-		}
-		int   best_cp     = -1;
-		float best_dist2  = std::numeric_limits<float>::infinity();
-		for (int idx : candidates) {
-			const CollisionCheckpoint &cp = checkpoints[idx];
+int vox_idx = get_voxel_index(in_point);
+if (vox_idx == -1)
+return -1;
+for (int i : voxel_grid[vox_idx]) {
+if (!checkpoints[i].start_plane.is_point_over(in_point))
+continue;
+if (checkpoints[i].end_plane.is_point_over(in_point))
+continue;
+candidates.push_back(i);
+}
+int   best_cp    = -1;
+float best_dist2 = std::numeric_limits<float>::infinity();
+for (int idx : candidates) {
+const CollisionCheckpoint &cp = checkpoints[idx];
 
 			// project pos onto segment
 			godot::Vector3 p1    = cp.start_plane.project(in_point);


### PR DESCRIPTION
## Summary
- add bounding & voxel grid members to `RaceTrack`
- compute track bounds on load and build checkpoint voxel grid
- lookup checkpoints via voxel grid for faster queries

## Testing
- `scons -Q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561dd3e93c832d8f6e002051824a88