### PR TITLE
Optimize checkpoint search via segment bounds

### DIFF
--- a/src/track/track_segment.h
+++ b/src/track/track_segment.h
@@ -4,17 +4,44 @@
 #include "track/road_modulation.h"
 #include "track/road_embed.h"
 #include "mxt_core/enums.h"
+#include <algorithm>
+
+struct SegmentAABB
+{
+	godot::Vector3 position;
+	godot::Vector3 size;
+	inline void expand_to(const godot::Vector3 &p)
+	{
+	float min_x = std::min(position.x, p.x);
+	float min_y = std::min(position.y, p.y);
+	float min_z = std::min(position.z, p.z);
+	float max_x = std::max(position.x + size.x, p.x);
+	float max_y = std::max(position.y + size.y, p.y);
+	float max_z = std::max(position.z + size.z, p.z);
+	position = godot::Vector3(min_x, min_y, min_z);
+	size = godot::Vector3(max_x - min_x, max_y - min_y, max_z - min_z);
+	}
+	inline bool has_point(const godot::Vector3 &p) const
+	{
+	return p.x >= position.x && p.x <= position.x + size.x &&
+	       p.y >= position.y && p.y <= position.y + size.y &&
+	       p.z >= position.z && p.z <= position.z + size.z;
+	}
+};
 
 class RoadShape;
 
 class TrackSegment
 {
 public:
-        float segment_length;
-        float left_rail_height;
-        float right_rail_height;
-        RoadShape* road_shape;
-        RoadTransformCurve* curve_matrix;
+float segment_length;
+float left_rail_height;
+float right_rail_height;
+RoadShape* road_shape;
+RoadTransformCurve* curve_matrix;
+SegmentAABB bounds;
+int first_checkpoint;
+int checkpoint_count;
 };
 
 class RoadShape


### PR DESCRIPTION
## Summary
- store `first_checkpoint` and `checkpoint_count` for each `TrackSegment`
- record segment checkpoint ranges while reading level data
- filter checkpoint loops by segment bounds and range

## Testing
- `scons -j4` *(fails: missing `godot-cpp/SConstruct`)*

------
https://chatgpt.com/codex/tasks/task_e_6856397ea3b4832d8c1f15c5b7a583f2