### PR TITLE
Randomize car definitions and load properties from GDScript

### DIFF
--- a/mxto/car_container_node.gd
+++ b/mxto/car_container_node.gd
@@ -2,11 +2,13 @@ class_name CarNodeContainer extends Node3D
 
 var num_cars := 1
 
-func instantiate_cars():
-	for child in get_children():
-		child.queue_free()
-	for i in num_cars:
-		var new_car := preload("res://vehicle/visual_car.tscn").instantiate()
-		add_child(new_car)
-		if i == 0:
-			new_car.car_camera.make_current()
+func instantiate_cars(definitions: Array):
+        for child in get_children():
+                child.queue_free()
+        num_cars = definitions.size()
+        for i in num_cars:
+                var new_car := preload("res://vehicle/visual_car.tscn").instantiate()
+                new_car.car_definition = definitions[i]
+                add_child(new_car)
+                if i == 0:
+                        new_car.car_camera.make_current()

--- a/src/main.h
+++ b/src/main.h
@@ -6,6 +6,7 @@
 #include "godot_cpp/classes/multi_mesh_instance3d.hpp"
 #include "godot_cpp/classes/multi_mesh.hpp"
 #include "godot_cpp/classes/stream_peer_buffer.hpp"
+#include "godot_cpp/variant/array.hpp"
 #include "track/racetrack.h"
 #include "mxt_core/heap_handler.h"
 #include "mxt_core/mtxa_stack.hpp"
@@ -46,7 +47,7 @@ namespace godot {
 			void set_car_node_container(godot::Node3D* p_car_node_container) { car_node_container = p_car_node_container; }
 			godot::Node3D* get_car_node_container() const { return car_node_container; }
 			void tick_gamesim();
-			void instantiate_gamesim(StreamPeerBuffer* in_buffer);
+                        void instantiate_gamesim(StreamPeerBuffer* in_buffer, godot::Array car_prop_buffers);
 			void destroy_gamesim();
 			void render_gamesim();
 			void save_state();


### PR DESCRIPTION
## Summary
- allow `GameSim.instantiate_gamesim` to accept serialized car properties
- generate random car definitions when starting a race
- load `.mxt_car_props` files in GDScript and pass them to C++
- create visual cars with their definition set before adding them to the tree

## Testing
- `scons -Q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b566b214832db1e128d82f4aa5b9