### PR TITLE
Introduce basic server-authoritative rollback

### DIFF
--- a/mxto/main.gd
+++ b/mxto/main.gd
@@ -89,9 +89,10 @@ func _on_start_button_pressed() -> void:
 
 	var level_buffer := StreamPeerBuffer.new()
 	level_buffer.data_array = FileAccess.get_file_as_bytes(info["mxt"])
-	game_sim.car_node_container = car_node_container
-	game_sim.instantiate_gamesim(level_buffer, car_props)
-	network_manager.host()
+        game_sim.car_node_container = car_node_container
+        game_sim.instantiate_gamesim(level_buffer, car_props)
+        network_manager.game_sim = game_sim
+        network_manager.host()
 	var obj_path = info["mxt"].get_basename() + ".obj"
 	if ResourceLoader.exists(obj_path):
 		debug_track_mesh.mesh = load(obj_path)
@@ -108,9 +109,10 @@ func _physics_process(delta: float) -> void:
 		if players.size() > 0:
 			local_input = players[0].get_input().to_dict()
 		network_manager.set_local_input(local_input)
-		var inputs := network_manager.collect_inputs()
-		game_sim.tick_gamesim(inputs)
-		game_sim.render_gamesim()
+                var inputs := network_manager.collect_inputs()
+                game_sim.tick_gamesim(inputs)
+                network_manager.post_tick()
+                game_sim.render_gamesim()
 
 func _unhandled_input(event: InputEvent) -> void:
 			if game_sim.sim_started and event.is_action_pressed("ui_cancel"):

--- a/mxto/netplay/network_manager.gd
+++ b/mxto/netplay/network_manager.gd
@@ -8,97 +8,134 @@ var is_server: bool = false
 var player_ids: Array = []
 var pending_inputs := {}
 var authoritative_inputs := {}
+var input_history := {}
+var sent_inputs := {}
 var last_local_input := NEUTRAL_INPUT.duplicate()
 var server_tick: int = 0
 var local_tick: int = 0
-var input_redundancy := 5
+var input_redundancy := ProjectSettings.get_setting("netplay/rollback/input_redundancy", 5)
+var game_sim: GameSim
+var last_received_tick := {}
+var last_ack_tick: int = -1
+var last_broadcast_inputs: Array = []
 
 func host(port: int = 3456, max_players: int = 4) -> int:
-		var peer := ENetMultiplayerPeer.new()
-		var err := peer.create_server(port, max_players)
-		if err != OK:
-				push_error("Failed to host: %s" % err)
-				return err
-		multiplayer.multiplayer_peer = peer
-		is_server = true
-		server_tick = 0
-		player_ids = [multiplayer.get_unique_id()]
-		multiplayer.peer_connected.connect(_on_peer_connected)
-		multiplayer.peer_disconnected.connect(_on_peer_disconnected)
-		return OK
+    var peer := ENetMultiplayerPeer.new()
+    var err := peer.create_server(port, max_players)
+    if err != OK:
+        push_error("Failed to host: %s" % err)
+        return err
+    multiplayer.multiplayer_peer = peer
+    is_server = true
+    server_tick = 0
+    last_received_tick.clear()
+    player_ids = [multiplayer.get_unique_id()]
+    multiplayer.peer_connected.connect(_on_peer_connected)
+    multiplayer.peer_disconnected.connect(_on_peer_disconnected)
+    return OK
 
 func join(ip: String, port: int = 3456) -> int:
-		var peer := ENetMultiplayerPeer.new()
-		var err := peer.create_client(ip, port)
-		if err != OK:
-				push_error("Failed to join server: %s" % err)
-				return err
-		multiplayer.multiplayer_peer = peer
-		is_server = false
-		local_tick = 0
-		player_ids = [multiplayer.get_unique_id()]
-		return OK
+    var peer := ENetMultiplayerPeer.new()
+    var err := peer.create_client(ip, port)
+    if err != OK:
+        push_error("Failed to join server: %s" % err)
+        return err
+    multiplayer.multiplayer_peer = peer
+    is_server = false
+    local_tick = 0
+    last_ack_tick = -1
+    input_history.clear()
+    sent_inputs.clear()
+    player_ids = [multiplayer.get_unique_id()]
+    return OK
 
 func _on_peer_connected(id: int) -> void:
-		if is_server:
-				player_ids.append(id)
-				rpc("_update_player_ids", player_ids)
+    if is_server:
+        player_ids.append(id)
+        rpc("_update_player_ids", player_ids)
 
 func _on_peer_disconnected(id: int) -> void:
-		if is_server:
-				player_ids.erase(id)
-				rpc("_update_player_ids", player_ids)
+    if is_server:
+        player_ids.erase(id)
+        rpc("_update_player_ids", player_ids)
 
 @rpc("any_peer")
 func _update_player_ids(ids: Array) -> void:
-		player_ids = ids
+    player_ids = ids
 
 func set_local_input(input: Dictionary) -> void:
-		last_local_input = input
+    last_local_input = input
 
 func collect_inputs() -> Array:
-		if is_server:
-				if not pending_inputs.has(server_tick):
-						pending_inputs[server_tick] = {}
-				pending_inputs[server_tick][multiplayer.get_unique_id()] = last_local_input
-				var frame_inputs: Array = []
-				var dict = pending_inputs[server_tick]
-				for id in player_ids:
-						if dict.has(id):
-								frame_inputs.append(dict[id])
-						else:
-								frame_inputs.append(NEUTRAL_INPUT)
-				pending_inputs.erase(server_tick)
-				_server_broadcast.rpc(server_tick, frame_inputs, player_ids)
-				server_tick += 1
-				return frame_inputs
-		else:
-				for i in input_redundancy:
-						_client_send_input.rpc_id(1, "_client_send_input", local_tick + i, last_local_input)
-				var frame_inputs: Array
-				if authoritative_inputs.has(local_tick):
-						frame_inputs = authoritative_inputs[local_tick]
-						authoritative_inputs.erase(local_tick)
-				else:
-						frame_inputs = []
-						for id in player_ids:
-								if id == multiplayer.get_unique_id():
-										frame_inputs.append(last_local_input)
-								else:
-										frame_inputs.append(NEUTRAL_INPUT)
-				local_tick += 1
-				return frame_inputs
+    if is_server:
+        if not pending_inputs.has(server_tick):
+            pending_inputs[server_tick] = {}
+        pending_inputs[server_tick][multiplayer.get_unique_id()] = last_local_input
+        var frame_inputs: Array = []
+        var dict = pending_inputs[server_tick]
+        for id in player_ids:
+            if dict.has(id):
+                frame_inputs.append(dict[id])
+            else:
+                frame_inputs.append(NEUTRAL_INPUT)
+        pending_inputs.erase(server_tick)
+        last_broadcast_inputs = frame_inputs
+        return frame_inputs
+    else:
+        sent_inputs[local_tick] = last_local_input
+        for key in sent_inputs.keys():
+            _client_send_input.rpc_id(1, "_client_send_input", key, sent_inputs[key])
+        var frame_inputs: Array
+        if authoritative_inputs.has(local_tick):
+            frame_inputs = authoritative_inputs[local_tick]
+            authoritative_inputs.erase(local_tick)
+        else:
+            frame_inputs = []
+            for id in player_ids:
+                if id == multiplayer.get_unique_id():
+                    frame_inputs.append(last_local_input)
+                else:
+                    frame_inputs.append(NEUTRAL_INPUT)
+        input_history[local_tick] = frame_inputs
+        local_tick += 1
+        return frame_inputs
 
-@rpc('any_peer', 'unreliable', 'call_local')
+@rpc("any_peer", "unreliable", "call_local")
 func _client_send_input(tick: int, input: Dictionary) -> void:
-		if is_server:
-				if not pending_inputs.has(tick):
-						pending_inputs[tick] = {}
-				pending_inputs[tick][multiplayer.get_remote_sender_id()] = input
+    if is_server:
+        if not pending_inputs.has(tick):
+            pending_inputs[tick] = {}
+        pending_inputs[tick][multiplayer.get_remote_sender_id()] = input
+        last_received_tick[multiplayer.get_remote_sender_id()] = tick
 
-@rpc('any_peer', 'unreliable', 'call_local')
-func _server_broadcast(tick: int, inputs: Array, ids: Array) -> void:
-		if not is_server:
-				server_tick = max(server_tick, tick + 1)
-				player_ids = ids
-				authoritative_inputs[tick] = inputs
+@rpc("any_peer", "unreliable", "call_local")
+func _server_broadcast(tick: int, inputs: Array, ids: Array, acks: Dictionary, state: PackedByteArray) -> void:
+    if not is_server:
+        server_tick = max(server_tick, tick + 1)
+        player_ids = ids
+        authoritative_inputs[tick] = inputs
+        if acks.has(multiplayer.get_unique_id()):
+            last_ack_tick = max(last_ack_tick, int(acks[multiplayer.get_unique_id()]))
+            for key in sent_inputs.keys():
+                if key <= last_ack_tick:
+                    sent_inputs.erase(key)
+        _handle_state(tick, state)
+
+func post_tick() -> void:
+    if is_server and game_sim != null:
+        var state = game_sim.get_state_data(server_tick)
+        _server_broadcast.rpc(server_tick, last_broadcast_inputs, player_ids, last_received_tick, state)
+        server_tick += 1
+
+func _handle_state(tick: int, state: PackedByteArray) -> void:
+    if game_sim == null:
+        return
+    var local_state: PackedByteArray = game_sim.get_state_data(tick)
+    if local_state != state:
+        game_sim.set_state_data(tick, state)
+        game_sim.load_state(tick)
+        var current := tick
+        while current < local_tick:
+            if input_history.has(current):
+                game_sim.tick_gamesim(input_history[current])
+            current += 1

--- a/mxto/project.godot
+++ b/mxto/project.godot
@@ -86,7 +86,7 @@ DPadUp={
 ]
 }
 
-[netfox]
+[netplay]
 
 time/tickrate=60
 time/max_ticks_per_frame=15

--- a/src/main.h
+++ b/src/main.h
@@ -52,10 +52,12 @@ namespace godot {
                         void tick_gamesim(godot::Array player_inputs);
                         void instantiate_gamesim(StreamPeerBuffer* in_buffer, godot::Array car_prop_buffers);
 			void destroy_gamesim();
-			void render_gamesim();
-			void save_state();
-			void load_state(int target_tick);
-	};
+                       void render_gamesim();
+                       void save_state();
+                       void load_state(int target_tick);
+                       godot::PackedByteArray get_state_data(int target_tick) const;
+                       void set_state_data(int target_tick, godot::PackedByteArray data);
+       };
 
 }
 


### PR DESCRIPTION
## Summary
- drop legacy `[netfox]` project settings and replace with `[netplay]`
- expose GameSim state buffer for networking
- overhaul NetworkManager for state broadcast, acknowledgements and rollback
- hook NetworkManager to GameSim from `main.gd`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68588c3005e8832d94bb6884e5b7b54b