### PR TITLE
Add car settings UI and networked player configuration

### DIFF
--- a/mxto/default_bus_layout.tres
+++ b/mxto/default_bus_layout.tres
@@ -1,0 +1,4 @@
+[gd_resource type="AudioBusLayout" format=3 uid="uid://b481emnuga7v8"]
+
+[resource]
+bus/0/volume_db = -30.1465

--- a/mxto/main.gd
+++ b/mxto/main.gd
@@ -25,12 +25,12 @@ var player_scene := preload("res://player/player_controller.tscn")
 var local_player_index: int = 0
 
 func _ready() -> void:
-        _load_tracks()
-        _load_car_definitions()
-        network_manager.race_started.connect(_on_network_race_started)
-        car_settings.hide()
-        car_settings_button.pressed.connect(_on_car_settings_button_pressed)
-        car_settings_button_lobby.pressed.connect(_on_car_settings_button_pressed)
+				_load_tracks()
+				_load_car_definitions()
+				network_manager.race_started.connect(_on_network_race_started)
+				car_settings.hide()
+				car_settings_button.pressed.connect(_on_car_settings_button_pressed)
+				car_settings_button_lobby.pressed.connect(_on_car_settings_button_pressed)
 
 func _load_tracks() -> void:
 	tracks.clear()
@@ -88,48 +88,48 @@ func _on_start_button_pressed() -> void:
 	lobby_control.visible = true
 
 func _on_join_button_pressed() -> void:
-        network_manager.join(ip_field.text)
-        start_race_button.disabled = true
-        $Control.visible = false
-        lobby_control.visible = true
+				network_manager.join(ip_field.text)
+				start_race_button.disabled = true
+				$Control.visible = false
+				lobby_control.visible = true
 
 func _on_car_settings_button_pressed() -> void:
-        car_settings.call("open_settings")
+				car_settings.call("open_settings")
 
 func _start_race(track_index: int, settings: Array) -> void:
-        if track_index < 0 or track_index >= tracks.size():
-                return
-        var info : Dictionary = tracks[track_index]
-        var chosen_defs : Array = []
-        var parsed_settings : Array = []
-        for d in settings:
-                if typeof(d) == TYPE_DICTIONARY:
-                        var ps := PlayerSettings.new()
-                        ps.from_dict(d)
-                        parsed_settings.append(ps)
-                        var def_res := load(ps.car_definition_path)
-                        if def_res != null:
-                                chosen_defs.append(def_res)
-        local_player_index = network_manager.player_ids.find(multiplayer.get_unique_id())
-        if local_player_index == -1:
-                local_player_index = 0
-        car_node_container.instantiate_cars(chosen_defs, network_manager.player_ids, local_player_index)
-        var idx := 0
-        for car:VisualCar in car_node_container.get_children():
-                car.game_manager = self
-                if idx < parsed_settings.size():
-                        car.player_settings = parsed_settings[idx]
-                idx += 1
-        for p in players:
-                p.queue_free()
-        players.clear()
-        for i in parsed_settings.size():
-                var pc := player_scene.instantiate()
-                pc.car_definition = chosen_defs[i]
-                pc.accel_setting = parsed_settings[i].accel_setting
-                pc.player_settings = parsed_settings[i]
-                add_child(pc)
-                players.append(pc)
+	if track_index < 0 or track_index >= tracks.size():
+		return
+	var info : Dictionary = tracks[track_index]
+	var chosen_defs : Array = []
+	var parsed_settings : Array = []
+	for d in settings:
+		if typeof(d) == TYPE_DICTIONARY:
+			var ps := PlayerSettings.new()
+			ps.from_dict(d)
+			parsed_settings.append(ps)
+			var def_res := load(ps.car_definition_path)
+			if def_res != null:
+				chosen_defs.append(def_res)
+	local_player_index = network_manager.player_ids.find(multiplayer.get_unique_id())
+	if local_player_index == -1:
+		local_player_index = 0
+	car_node_container.instantiate_cars(chosen_defs, network_manager.player_ids, local_player_index)
+	var idx := 0
+	for car:VisualCar in car_node_container.get_children():
+		car.game_manager = self
+		if idx < parsed_settings.size():
+			car.player_settings = parsed_settings[idx]
+		idx += 1
+	for p in players:
+		p.queue_free()
+	players.clear()
+	for i in parsed_settings.size():
+		var pc := player_scene.instantiate()
+		pc.car_definition = chosen_defs[i]
+		pc.accel_setting = parsed_settings[i].accel_setting
+		pc.player_settings = parsed_settings[i]
+		add_child(pc)
+		players.append(pc)
 	var car_props : Array = []
 	for def in chosen_defs:
 		var bytes := FileAccess.get_file_as_bytes(def.car_definition)
@@ -149,28 +149,28 @@ func _start_race(track_index: int, settings: Array) -> void:
 				debug_track_mesh.mesh.surface_set_material(i, preload("res://asset/debug_track_mat.tres"))
 
 func _on_start_race_button_pressed() -> void:
-        if network_manager.is_server:
-                var settings_array : Array = []
-                for id in network_manager.player_ids:
-                        var ps := network_manager.player_settings.get(id, null)
-                        if ps == null:
-                                var def_path := car_definitions[randi() % car_definitions.size()].resource_path
-                                ps = {"car_definition_path": def_path, "accel_setting": 1.0, "username": str(id)}
-                        settings_array.append(ps)
-                network_manager.send_start_race(lobby_track_selector.selected, settings_array)
+				if network_manager.is_server:
+								var settings_array : Array = []
+								for id in network_manager.player_ids:
+												var ps = network_manager.player_settings.get(id, null)
+												if ps == null:
+																var def_path = car_definitions[randi() % car_definitions.size()].resource_path
+																ps = {"car_definition_path": def_path, "accel_setting": 1.0, "username": str(id)}
+												settings_array.append(ps)
+								network_manager.send_start_race(lobby_track_selector.selected, settings_array)
 
 func _on_network_race_started(track_index: int, settings: Array) -> void:
-        _start_race(track_index, settings)
+				_start_race(track_index, settings)
 
 func _update_player_list() -> void:
-        player_list.clear()
-        for id in network_manager.player_ids:
-                var name := str(id)
-                if network_manager.player_settings.has(id):
-                        var ps := network_manager.player_settings[id]
-                        if typeof(ps) == TYPE_DICTIONARY and ps.has("username"):
-                                name = ps["username"]
-                player_list.add_item(name)
+				player_list.clear()
+				for id in network_manager.player_ids:
+								var name := str(id)
+								if network_manager.player_settings.has(id):
+												var ps = network_manager.player_settings[id]
+												if typeof(ps) == TYPE_DICTIONARY and ps.has("username"):
+																name = ps["username"]
+								player_list.add_item(name)
 
 func _physics_process(delta: float) -> void:
 	DebugDraw3D.scoped_config().set_no_depth_test(true)

--- a/mxto/main.gd
+++ b/mxto/main.gd
@@ -12,6 +12,9 @@ class_name GameManager extends Node
 @onready var car_node_container: CarNodeContainer = $GameWorld/CarNodeContainer
 @onready var debug_track_mesh: MeshInstance3D = $GameWorld/DebugTrackMeshContainer/DebugTrackMesh
 @onready var network_manager: NetworkManager = $NetworkManager
+@onready var car_settings: Control = $CarSettings
+@onready var car_settings_button: Button = $Control/CarSettingsButton
+@onready var car_settings_button_lobby: Button = $Lobby/CarSettingsButton
 
 const PlayerInputClass = preload("res://player/player_input.gd")
 
@@ -22,9 +25,12 @@ var player_scene := preload("res://player/player_controller.tscn")
 var local_player_index: int = 0
 
 func _ready() -> void:
-	_load_tracks()
-	_load_car_definitions()
-	network_manager.race_started.connect(_on_network_race_started)
+        _load_tracks()
+        _load_car_definitions()
+        network_manager.race_started.connect(_on_network_race_started)
+        car_settings.hide()
+        car_settings_button.pressed.connect(_on_car_settings_button_pressed)
+        car_settings_button_lobby.pressed.connect(_on_car_settings_button_pressed)
 
 func _load_tracks() -> void:
 	tracks.clear()
@@ -82,34 +88,48 @@ func _on_start_button_pressed() -> void:
 	lobby_control.visible = true
 
 func _on_join_button_pressed() -> void:
-	network_manager.join(ip_field.text)
-	start_race_button.disabled = true
-	$Control.visible = false
-	lobby_control.visible = true
+        network_manager.join(ip_field.text)
+        start_race_button.disabled = true
+        $Control.visible = false
+        lobby_control.visible = true
 
-func _start_race(track_index: int, car_defs: Array) -> void:
-	if track_index < 0 or track_index >= tracks.size():
-		return
-	var info : Dictionary = tracks[track_index]
-	var chosen_defs : Array = []
-	for path in car_defs:
-		var def_res := load(path)
-		if def_res != null:
-			chosen_defs.append(def_res)
-	local_player_index = network_manager.player_ids.find(multiplayer.get_unique_id())
-	if local_player_index == -1:
-		local_player_index = 0
-	car_node_container.instantiate_cars(chosen_defs, network_manager.player_ids, local_player_index)
-	for car:VisualCar in car_node_container.get_children():
-		car.game_manager = self
-	for p in players:
-		p.queue_free()
-	players.clear()
-	for i in chosen_defs.size():
-		var pc := player_scene.instantiate()
-		pc.car_definition = chosen_defs[i]
-		add_child(pc)
-		players.append(pc)
+func _on_car_settings_button_pressed() -> void:
+        car_settings.call("open_settings")
+
+func _start_race(track_index: int, settings: Array) -> void:
+        if track_index < 0 or track_index >= tracks.size():
+                return
+        var info : Dictionary = tracks[track_index]
+        var chosen_defs : Array = []
+        var parsed_settings : Array = []
+        for d in settings:
+                if typeof(d) == TYPE_DICTIONARY:
+                        var ps := PlayerSettings.new()
+                        ps.from_dict(d)
+                        parsed_settings.append(ps)
+                        var def_res := load(ps.car_definition_path)
+                        if def_res != null:
+                                chosen_defs.append(def_res)
+        local_player_index = network_manager.player_ids.find(multiplayer.get_unique_id())
+        if local_player_index == -1:
+                local_player_index = 0
+        car_node_container.instantiate_cars(chosen_defs, network_manager.player_ids, local_player_index)
+        var idx := 0
+        for car:VisualCar in car_node_container.get_children():
+                car.game_manager = self
+                if idx < parsed_settings.size():
+                        car.player_settings = parsed_settings[idx]
+                idx += 1
+        for p in players:
+                p.queue_free()
+        players.clear()
+        for i in parsed_settings.size():
+                var pc := player_scene.instantiate()
+                pc.car_definition = chosen_defs[i]
+                pc.accel_setting = parsed_settings[i].accel_setting
+                pc.player_settings = parsed_settings[i]
+                add_child(pc)
+                players.append(pc)
 	var car_props : Array = []
 	for def in chosen_defs:
 		var bytes := FileAccess.get_file_as_bytes(def.car_definition)
@@ -129,20 +149,28 @@ func _start_race(track_index: int, car_defs: Array) -> void:
 				debug_track_mesh.mesh.surface_set_material(i, preload("res://asset/debug_track_mat.tres"))
 
 func _on_start_race_button_pressed() -> void:
-	if network_manager.is_server:
-		var player_count := network_manager.player_ids.size()
-		var chosen_defs_paths : Array = []
-		for i in player_count:
-			chosen_defs_paths.append(car_definitions[randi() % car_definitions.size()].resource_path)
-		network_manager.send_start_race(lobby_track_selector.selected, chosen_defs_paths)
+        if network_manager.is_server:
+                var settings_array : Array = []
+                for id in network_manager.player_ids:
+                        var ps := network_manager.player_settings.get(id, null)
+                        if ps == null:
+                                var def_path := car_definitions[randi() % car_definitions.size()].resource_path
+                                ps = {"car_definition_path": def_path, "accel_setting": 1.0, "username": str(id)}
+                        settings_array.append(ps)
+                network_manager.send_start_race(lobby_track_selector.selected, settings_array)
 
-func _on_network_race_started(track_index: int, car_defs: Array) -> void:
-			_start_race(track_index, car_defs)
+func _on_network_race_started(track_index: int, settings: Array) -> void:
+        _start_race(track_index, settings)
 
 func _update_player_list() -> void:
-	player_list.clear()
-	for id in network_manager.player_ids:
-		player_list.add_item(str(id))
+        player_list.clear()
+        for id in network_manager.player_ids:
+                var name := str(id)
+                if network_manager.player_settings.has(id):
+                        var ps := network_manager.player_settings[id]
+                        if typeof(ps) == TYPE_DICTIONARY and ps.has("username"):
+                                name = ps["username"]
+                player_list.add_item(name)
 
 func _physics_process(delta: float) -> void:
 	DebugDraw3D.scoped_config().set_no_depth_test(true)

--- a/mxto/main.tscn
+++ b/mxto/main.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=8 format=3 uid="uid://brrsssxopnp7c"]
+[gd_scene load_steps=9 format=3 uid="uid://brrsssxopnp7c"]
 
 [ext_resource type="Script" uid="uid://dfdmwafou3th7" path="res://main.gd" id="1_tjhrj"]
 [ext_resource type="ArrayMesh" uid="uid://2biir4cy4wk8" path="res://track/weird_track_2/weird_track_2.obj" id="3_1bvp3"]
 [ext_resource type="Script" uid="uid://odaiawvcj4yf" path="res://car_container_node.gd" id="3_h2yge"]
 [ext_resource type="Script" uid="uid://cq1kmqnd5qooc" path="res://netplay/network_manager.gd" id="3_netplay"]
+[ext_resource type="PackedScene" path="res://ui/car_settings.tscn" id="3_carsettings"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_c0w6o"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -94,6 +95,21 @@ grow_horizontal = 2
 grow_vertical = 2
 text = "Join"
 
+[node name="CarSettingsButton" type="Button" parent="Control"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -115.0
+offset_top = 104.0
+offset_right = 115.0
+offset_bottom = 134.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Car Settings"
+
 [node name="Lobby" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 15
@@ -136,6 +152,21 @@ grow_horizontal = 2
 grow_vertical = 2
 text = "Start Race"
 
+[node name="CarSettingsButton" type="Button" parent="Lobby"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -115.0
+offset_top = 74.0
+offset_right = 115.0
+offset_bottom = 104.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "Car Settings"
+
 [node name="GameWorld" type="Node3D" parent="."]
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="GameWorld"]
@@ -156,6 +187,10 @@ transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 
 mesh = ExtResource("3_1bvp3")
 skeleton = NodePath("")
 
+[node name="CarSettings" parent="." instance=ExtResource("3_carsettings")]
+
 [connection signal="pressed" from="Control/StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="pressed" from="Control/JoinButton" to="." method="_on_join_button_pressed"]
+[connection signal="pressed" from="Control/CarSettingsButton" to="." method="_on_car_settings_button_pressed"]
+[connection signal="pressed" from="Lobby/CarSettingsButton" to="." method="_on_car_settings_button_pressed"]
 [connection signal="pressed" from="Lobby/StartRaceButton" to="." method="_on_start_race_button_pressed"]

--- a/mxto/main.tscn
+++ b/mxto/main.tscn
@@ -2,9 +2,9 @@
 
 [ext_resource type="Script" uid="uid://dfdmwafou3th7" path="res://main.gd" id="1_tjhrj"]
 [ext_resource type="ArrayMesh" uid="uid://2biir4cy4wk8" path="res://track/weird_track_2/weird_track_2.obj" id="3_1bvp3"]
+[ext_resource type="PackedScene" uid="uid://d3fgxyahmbbxa" path="res://ui/car_settings.tscn" id="3_carsettings"]
 [ext_resource type="Script" uid="uid://odaiawvcj4yf" path="res://car_container_node.gd" id="3_h2yge"]
 [ext_resource type="Script" uid="uid://cq1kmqnd5qooc" path="res://netplay/network_manager.gd" id="3_netplay"]
-[ext_resource type="PackedScene" path="res://ui/car_settings.tscn" id="3_carsettings"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_c0w6o"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -28,7 +28,6 @@ script = ExtResource("1_tjhrj")
 script = ExtResource("3_netplay")
 
 [node name="Control" type="Control" parent="."]
-visible = false
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -111,6 +110,7 @@ grow_vertical = 2
 text = "Car Settings"
 
 [node name="Lobby" type="Control" parent="."]
+visible = false
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -188,9 +188,10 @@ mesh = ExtResource("3_1bvp3")
 skeleton = NodePath("")
 
 [node name="CarSettings" parent="." instance=ExtResource("3_carsettings")]
+visible = false
 
 [connection signal="pressed" from="Control/StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="pressed" from="Control/JoinButton" to="." method="_on_join_button_pressed"]
 [connection signal="pressed" from="Control/CarSettingsButton" to="." method="_on_car_settings_button_pressed"]
-[connection signal="pressed" from="Lobby/CarSettingsButton" to="." method="_on_car_settings_button_pressed"]
 [connection signal="pressed" from="Lobby/StartRaceButton" to="." method="_on_start_race_button_pressed"]
+[connection signal="pressed" from="Lobby/CarSettingsButton" to="." method="_on_car_settings_button_pressed"]

--- a/mxto/netplay/network_manager.gd
+++ b/mxto/netplay/network_manager.gd
@@ -49,10 +49,10 @@ func host(port: int = 27016, max_players: int = 64) -> int:
 	rtt_s = 0.0
 	desired_ahead_ticks = 0.0
 	sent_input_times.clear()
-        last_received_tick.clear()
-        player_ids = [multiplayer.get_unique_id()]
-        player_settings.clear()
-        multiplayer.peer_connected.connect(_on_peer_connected)
+	last_received_tick.clear()
+	player_ids = [multiplayer.get_unique_id()]
+	player_settings.clear()
+	multiplayer.peer_connected.connect(_on_peer_connected)
 	multiplayer.peer_disconnected.connect(_on_peer_disconnected)
 	return OK
 
@@ -71,10 +71,10 @@ func join(ip: String, port: int = 27016) -> int:
 	desired_ahead_ticks = 2.0
 	sent_input_times.clear()
 	input_history.clear()
-        sent_inputs.clear()
-        player_ids = [multiplayer.get_unique_id()]
-        player_settings.clear()
-        return OK
+	sent_inputs.clear()
+	player_ids = [multiplayer.get_unique_id()]
+	player_settings.clear()
+	return OK
 
 func _on_peer_connected(id: int) -> void:
 	if is_server:
@@ -92,25 +92,25 @@ func _update_player_ids(ids: Array) -> void:
 
 @rpc("any_peer")
 func start_race(track_index: int, settings: Array) -> void:
-        emit_signal("race_started", track_index, settings)
+				emit_signal("race_started", track_index, settings)
 
 func send_start_race(track_index: int, settings: Array) -> void:
-        if is_server:
-                start_race.rpc(track_index, settings)
-                start_race(track_index, settings)
-        else:
-                start_race.rpc_id(1, track_index, settings)
+				if is_server:
+								start_race.rpc(track_index, settings)
+								start_race(track_index, settings)
+				else:
+								start_race.rpc_id(1, track_index, settings)
 
 func send_player_settings(settings: Dictionary) -> void:
-        if is_server:
-                update_player_settings(settings)
-        else:
-                update_player_settings.rpc_id(1, settings)
-                player_settings[multiplayer.get_unique_id()] = settings
+				if is_server:
+								update_player_settings(settings)
+				else:
+								update_player_settings.rpc_id(1, settings)
+								player_settings[multiplayer.get_unique_id()] = settings
 
 @rpc("any_peer")
 func update_player_settings(settings: Dictionary) -> void:
-        player_settings[multiplayer.get_remote_sender_id()] = settings
+				player_settings[multiplayer.get_remote_sender_id()] = settings
 
 func set_local_input(input: Dictionary) -> void:
 	last_local_input = input
@@ -228,10 +228,10 @@ func disconnect_from_server() -> void:
 	server_tick = 0
 	local_tick = 0
 	target_tick = 0
-        last_received_tick.clear()
-        last_ack_tick = -1
-        last_broadcast_inputs.clear()
-        player_settings.clear()
+	last_received_tick.clear()
+	last_ack_tick = -1
+	last_broadcast_inputs.clear()
+	player_settings.clear()
 
 func _update_desired_ahead() -> void:
 	desired_ahead_ticks = ((rtt_s * 0.5) + JITTER_BUFFER) / base_wait_time

--- a/mxto/netplay/network_manager.gd
+++ b/mxto/netplay/network_manager.gd
@@ -1,7 +1,7 @@
 class_name NetworkManager
 extends Node
 
-signal race_started(track_index, car_defs)
+signal race_started(track_index, player_settings)
 
 const PlayerInputClass = preload("res://player/player_input.gd")
 var NEUTRAL_INPUT = PlayerInputClass.new().to_dict()
@@ -30,6 +30,7 @@ const JITTER_BUFFER := 0.016
 const RTT_SMOOTHING := 0.1
 const SPEED_ADJUST_STEP := 0.005
 var _accum: float = 0.0	# local frame accumulator
+var player_settings := {}
 
 func _physics_process(delta: float) -> void:
 	if is_server and game_sim != null and game_sim.sim_started:
@@ -48,9 +49,10 @@ func host(port: int = 27016, max_players: int = 64) -> int:
 	rtt_s = 0.0
 	desired_ahead_ticks = 0.0
 	sent_input_times.clear()
-	last_received_tick.clear()
-	player_ids = [multiplayer.get_unique_id()]
-	multiplayer.peer_connected.connect(_on_peer_connected)
+        last_received_tick.clear()
+        player_ids = [multiplayer.get_unique_id()]
+        player_settings.clear()
+        multiplayer.peer_connected.connect(_on_peer_connected)
 	multiplayer.peer_disconnected.connect(_on_peer_disconnected)
 	return OK
 
@@ -69,9 +71,10 @@ func join(ip: String, port: int = 27016) -> int:
 	desired_ahead_ticks = 2.0
 	sent_input_times.clear()
 	input_history.clear()
-	sent_inputs.clear()
-	player_ids = [multiplayer.get_unique_id()]
-	return OK
+        sent_inputs.clear()
+        player_ids = [multiplayer.get_unique_id()]
+        player_settings.clear()
+        return OK
 
 func _on_peer_connected(id: int) -> void:
 	if is_server:
@@ -88,15 +91,26 @@ func _update_player_ids(ids: Array) -> void:
 	player_ids = ids
 
 @rpc("any_peer")
-func start_race(track_index: int, car_defs: Array) -> void:
-	emit_signal("race_started", track_index, car_defs)
+func start_race(track_index: int, settings: Array) -> void:
+        emit_signal("race_started", track_index, settings)
 
-func send_start_race(track_index: int, car_defs: Array) -> void:
-	if is_server:
-		start_race.rpc(track_index, car_defs)
-		start_race(track_index, car_defs)
-	else:
-		start_race.rpc_id(1, track_index, car_defs)
+func send_start_race(track_index: int, settings: Array) -> void:
+        if is_server:
+                start_race.rpc(track_index, settings)
+                start_race(track_index, settings)
+        else:
+                start_race.rpc_id(1, track_index, settings)
+
+func send_player_settings(settings: Dictionary) -> void:
+        if is_server:
+                update_player_settings(settings)
+        else:
+                update_player_settings.rpc_id(1, settings)
+                player_settings[multiplayer.get_unique_id()] = settings
+
+@rpc("any_peer")
+func update_player_settings(settings: Dictionary) -> void:
+        player_settings[multiplayer.get_remote_sender_id()] = settings
 
 func set_local_input(input: Dictionary) -> void:
 	last_local_input = input
@@ -214,9 +228,10 @@ func disconnect_from_server() -> void:
 	server_tick = 0
 	local_tick = 0
 	target_tick = 0
-	last_received_tick.clear()
-	last_ack_tick = -1
-	last_broadcast_inputs.clear()
+        last_received_tick.clear()
+        last_ack_tick = -1
+        last_broadcast_inputs.clear()
+        player_settings.clear()
 
 func _update_desired_ahead() -> void:
 	desired_ahead_ticks = ((rtt_s * 0.5) + JITTER_BUFFER) / base_wait_time

--- a/mxto/player/player_controller.gd
+++ b/mxto/player/player_controller.gd
@@ -3,6 +3,7 @@ extends Node
 
 var car_definition: Resource
 var accel_setting: float = 1.0
+var player_settings: Resource
 
 func get_input() -> PlayerInput:
 	var p := PlayerInput.new()

--- a/mxto/player/player_settings.gd
+++ b/mxto/player/player_settings.gd
@@ -1,0 +1,21 @@
+class_name PlayerSettings
+extends Resource
+
+@export var username: String = "Player"
+@export var car_definition_path: String = ""
+@export var accel_setting: float = 1.0
+
+func to_dict() -> Dictionary:
+    return {
+        "username": username,
+        "car_definition_path": car_definition_path,
+        "accel_setting": accel_setting,
+    }
+
+func from_dict(data: Dictionary) -> void:
+    if data.has("username"):
+        username = str(data["username"])
+    if data.has("car_definition_path"):
+        car_definition_path = str(data["car_definition_path"])
+    if data.has("accel_setting"):
+        accel_setting = float(data["accel_setting"])

--- a/mxto/ui/car_settings.gd
+++ b/mxto/ui/car_settings.gd
@@ -11,65 +11,65 @@ var player_settings: PlayerSettings = PlayerSettings.new()
 var car_defs: Array = []
 
 func _ready() -> void:
-    game_manager = get_parent() as GameManager
-    _load_car_defs()
-    _load_settings()
-    _update_controls()
-    machine_setting_slider.value_changed.connect(_on_slider_changed)
-    vehicle_selector.item_selected.connect(_on_vehicle_selected)
-    pilot_name_input.text_changed.connect(_on_name_changed)
-    close_settings.pressed.connect(_on_close_pressed)
+		game_manager = get_parent() as GameManager
+		_load_car_defs()
+		_load_settings()
+		_update_controls()
+		machine_setting_slider.value_changed.connect(_on_slider_changed)
+		vehicle_selector.item_selected.connect(_on_vehicle_selected)
+		pilot_name_input.text_changed.connect(_on_name_changed)
+		close_settings.pressed.connect(_on_close_pressed)
 
 func _load_car_defs() -> void:
-    if game_manager != null:
-        car_defs = game_manager.car_definitions
-    vehicle_selector.clear()
-    for def in car_defs:
-        vehicle_selector.add_item(def.name)
+		if game_manager != null:
+				car_defs = game_manager.car_definitions
+		vehicle_selector.clear()
+		for def in car_defs:
+				vehicle_selector.add_item(def.name)
 
 func _load_settings() -> void:
-    var path := "user://player_settings.json"
-    if FileAccess.file_exists(path):
-        var data = JSON.parse_string(FileAccess.get_file_as_string(path))
-        if typeof(data) == TYPE_DICTIONARY:
-            player_settings.from_dict(data)
+		var path := "user://player_settings.json"
+		if FileAccess.file_exists(path):
+				var data = JSON.parse_string(FileAccess.get_file_as_string(path))
+				if typeof(data) == TYPE_DICTIONARY:
+						player_settings.from_dict(data)
 
 func _save_settings() -> void:
-    var path := "user://player_settings.json"
-    var file = FileAccess.open(path, FileAccess.WRITE)
-    file.store_string(JSON.stringify(player_settings.to_dict()))
-    file.close()
-    if game_manager:
-        game_manager.network_manager.send_player_settings(player_settings.to_dict())
+		var path := "user://player_settings.json"
+		var file = FileAccess.open(path, FileAccess.WRITE)
+		file.store_string(JSON.stringify(player_settings.to_dict()))
+		file.close()
+		if game_manager:
+				game_manager.network_manager.send_player_settings(player_settings.to_dict())
 
 func _update_controls() -> void:
-    machine_setting_slider.value = player_settings.accel_setting * 100.0
-    machine_setting_percent.text = str(roundi(machine_setting_slider.value)) + "%"
-    pilot_name_input.text = player_settings.username
-    var idx := 0
-    for i in car_defs.size():
-        if car_defs[i].resource_path == player_settings.car_definition_path:
-            idx = i
-            break
-    if car_defs.size() > 0:
-        vehicle_selector.select(idx)
+		machine_setting_slider.value = player_settings.accel_setting * 100.0
+		machine_setting_percent.text = str(roundi(machine_setting_slider.value)) + "%"
+		pilot_name_input.text = player_settings.username
+		var idx := 0
+		for i in car_defs.size():
+				if car_defs[i].resource_path == player_settings.car_definition_path:
+						idx = i
+						break
+		if car_defs.size() > 0:
+				vehicle_selector.select(idx)
 
 func _on_slider_changed(value: float) -> void:
-    machine_setting_percent.text = str(roundi(value)) + "%"
-    player_settings.accel_setting = value / 100.0
+		machine_setting_percent.text = str(roundi(value)) + "%"
+		player_settings.accel_setting = value / 100.0
 
 func _on_vehicle_selected(index: int) -> void:
-    if index >= 0 and index < car_defs.size():
-        player_settings.car_definition_path = car_defs[index].resource_path
+		if index >= 0 and index < car_defs.size():
+				player_settings.car_definition_path = car_defs[index].resource_path
 
 func _on_name_changed(new_text: String) -> void:
-    player_settings.username = new_text
+		player_settings.username = new_text
 
 func _on_close_pressed() -> void:
-    _save_settings()
-    hide()
+		_save_settings()
+		hide()
 
 func open_settings() -> void:
-    _load_settings()
-    _update_controls()
-    show()
+		_load_settings()
+		_update_controls()
+		show()

--- a/mxto/ui/car_settings.gd
+++ b/mxto/ui/car_settings.gd
@@ -5,3 +5,71 @@ extends Control
 @onready var vehicle_selector: ItemList = $VehicleSelector
 @onready var close_settings: Button = $CloseSettings
 @onready var pilot_name_input: LineEdit = $PilotNameInput
+
+var game_manager: GameManager
+var player_settings: PlayerSettings = PlayerSettings.new()
+var car_defs: Array = []
+
+func _ready() -> void:
+    game_manager = get_parent() as GameManager
+    _load_car_defs()
+    _load_settings()
+    _update_controls()
+    machine_setting_slider.value_changed.connect(_on_slider_changed)
+    vehicle_selector.item_selected.connect(_on_vehicle_selected)
+    pilot_name_input.text_changed.connect(_on_name_changed)
+    close_settings.pressed.connect(_on_close_pressed)
+
+func _load_car_defs() -> void:
+    if game_manager != null:
+        car_defs = game_manager.car_definitions
+    vehicle_selector.clear()
+    for def in car_defs:
+        vehicle_selector.add_item(def.name)
+
+func _load_settings() -> void:
+    var path := "user://player_settings.json"
+    if FileAccess.file_exists(path):
+        var data = JSON.parse_string(FileAccess.get_file_as_string(path))
+        if typeof(data) == TYPE_DICTIONARY:
+            player_settings.from_dict(data)
+
+func _save_settings() -> void:
+    var path := "user://player_settings.json"
+    var file = FileAccess.open(path, FileAccess.WRITE)
+    file.store_string(JSON.stringify(player_settings.to_dict()))
+    file.close()
+    if game_manager:
+        game_manager.network_manager.send_player_settings(player_settings.to_dict())
+
+func _update_controls() -> void:
+    machine_setting_slider.value = player_settings.accel_setting * 100.0
+    machine_setting_percent.text = str(roundi(machine_setting_slider.value)) + "%"
+    pilot_name_input.text = player_settings.username
+    var idx := 0
+    for i in car_defs.size():
+        if car_defs[i].resource_path == player_settings.car_definition_path:
+            idx = i
+            break
+    if car_defs.size() > 0:
+        vehicle_selector.select(idx)
+
+func _on_slider_changed(value: float) -> void:
+    machine_setting_percent.text = str(roundi(value)) + "%"
+    player_settings.accel_setting = value / 100.0
+
+func _on_vehicle_selected(index: int) -> void:
+    if index >= 0 and index < car_defs.size():
+        player_settings.car_definition_path = car_defs[index].resource_path
+
+func _on_name_changed(new_text: String) -> void:
+    player_settings.username = new_text
+
+func _on_close_pressed() -> void:
+    _save_settings()
+    hide()
+
+func open_settings() -> void:
+    _load_settings()
+    _update_controls()
+    show()

--- a/mxto/ui/race_hud.gd
+++ b/mxto/ui/race_hud.gd
@@ -100,12 +100,12 @@ func _process( _delta:float ) -> void:
 	for i in cars.size():
 		if cars[i] == car or cars[i].owning_id == local_id:
 			our_place = i + 1
-               if i < leaderboard_container.get_child_count():
-                       var label := leaderboard_container.get_child(i)
-                       var name := str(cars[i].owning_id)
-                       if cars[i].player_settings != null and cars[i].player_settings.has_method("get"):
-                               name = cars[i].player_settings.username
-                       label.text = str(i + 1) + ". " + name
+			if i < leaderboard_container.get_child_count():
+				var label := leaderboard_container.get_child(i)
+				var use_name := str(cars[i].owning_id)
+				if cars[i].player_settings != null and cars[i].player_settings.has_method("get"):
+					use_name = cars[i].player_settings.username
+					label.text = str(i + 1) + ". " + use_name
 	for i in range(cars.size(), leaderboard_container.get_child_count()):
 		leaderboard_container.get_child(i).text = ""
 

--- a/mxto/ui/race_hud.gd
+++ b/mxto/ui/race_hud.gd
@@ -100,10 +100,12 @@ func _process( _delta:float ) -> void:
 	for i in cars.size():
 		if cars[i] == car or cars[i].owning_id == local_id:
 			our_place = i + 1
-		if i < leaderboard_container.get_child_count():
-			var label := leaderboard_container.get_child(i)
-			var name := str(cars[i].owning_id)
-			label.text = str(i + 1) + ". " + name
+               if i < leaderboard_container.get_child_count():
+                       var label := leaderboard_container.get_child(i)
+                       var name := str(cars[i].owning_id)
+                       if cars[i].player_settings != null and cars[i].player_settings.has_method("get"):
+                               name = cars[i].player_settings.username
+                       label.text = str(i + 1) + ". " + name
 	for i in range(cars.size(), leaderboard_container.get_child_count()):
 		leaderboard_container.get_child(i).text = ""
 

--- a/mxto/vehicle/visual_car.gd
+++ b/mxto/vehicle/visual_car.gd
@@ -71,6 +71,7 @@ enum FZ_TC{
 @onready var strafe_sound: AudioStreamPlayer3D = $CarTransform/AudioStreamPlayer3D6
 
 var owning_id : int = 0
+var player_settings: Resource
 var game_manager : GameManager
 @onready var race_hud: RaceHud = $race_hud
 @onready var car_transform: Node3D = $CarTransform


### PR DESCRIPTION
## Summary
- implement `PlayerSettings` resource to hold user car setup
- hook up new car settings UI with save/load and networking
- network player settings via `NetworkManager`
- allow host to start races using networked settings
- display player names in HUD and lobby

## Testing
- `scons -Q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a3b5f3eb0832d864a97b24d225c25