### PR TITLE
Use players' custom car data

### DIFF
--- a/mxto/main.gd
+++ b/mxto/main.gd
@@ -132,14 +132,20 @@ func _start_race(track_index: int, settings: Array) -> void:
 		pc.player_settings = parsed_settings[i]
 		add_child(pc)
 		players.append(pc)
-	var car_props : Array = []
-	for def in chosen_defs:
-		var bytes := FileAccess.get_file_as_bytes(def.car_definition)
-		car_props.append(bytes)
-	var level_buffer := StreamPeerBuffer.new()
-	level_buffer.data_array = FileAccess.get_file_as_bytes(info["mxt"])
-	game_sim.car_node_container = car_node_container
-	game_sim.instantiate_gamesim(level_buffer, car_props)
+        var car_props : Array = []
+        var accel_settings_arr : Array = []
+        for idx in chosen_defs.size():
+                var def = chosen_defs[idx]
+                var bytes := FileAccess.get_file_as_bytes(def.car_definition)
+                car_props.append(bytes)
+                if idx < parsed_settings.size():
+                        accel_settings_arr.append(parsed_settings[idx].accel_setting)
+                else:
+                        accel_settings_arr.append(1.0)
+        var level_buffer := StreamPeerBuffer.new()
+        level_buffer.data_array = FileAccess.get_file_as_bytes(info["mxt"])
+        game_sim.car_node_container = car_node_container
+        game_sim.instantiate_gamesim(level_buffer, car_props, accel_settings_arr)
 	network_manager.game_sim = game_sim
 	var obj_path = info["mxt"].get_basename() + ".obj"
 	if ResourceLoader.exists(obj_path):

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ using namespace godot;
 
 void GameSim::_bind_methods()
 {
-	ClassDB::bind_method(D_METHOD("instantiate_gamesim", "lvldat_buf", "car_prop_buffers"), &GameSim::instantiate_gamesim);
+        ClassDB::bind_method(D_METHOD("instantiate_gamesim", "lvldat_buf", "car_prop_buffers", "accel_settings"), &GameSim::instantiate_gamesim);
 	ClassDB::bind_method(D_METHOD("destroy_gamesim"), &GameSim::destroy_gamesim);
 	ClassDB::bind_method(D_METHOD("tick_gamesim", "player_inputs"), &GameSim::tick_gamesim);
 	ClassDB::bind_method(D_METHOD("render_gamesim"), &GameSim::render_gamesim);
@@ -123,7 +123,7 @@ void GameSim::tick_gamesim(godot::Array player_inputs)
 	//dd3d->call("draw_points", car_positions, 0, 1.0f, godot::Color(1.f, 0.f, 0.f), 0.0166666);
 }
 
-void GameSim::instantiate_gamesim(StreamPeerBuffer* lvldat_buf, godot::Array car_prop_buffers)
+void GameSim::instantiate_gamesim(StreamPeerBuffer* lvldat_buf, godot::Array car_prop_buffers, godot::Array accel_settings)
 {
 	if (Engine::get_singleton()->is_editor_hint()) return;
 
@@ -456,11 +456,11 @@ void GameSim::instantiate_gamesim(StreamPeerBuffer* lvldat_buf, godot::Array car
 	}
 
 
-	int requested_cars = car_prop_buffers.size() > 0 ? car_prop_buffers.size() : 1;
-	PhysicsCarProperties* props_array = nullptr;
-	cars = gamestate_data.create_and_allocate_cars(requested_cars, &props_array);
-	car_properties_array = props_array;
-	num_cars = requested_cars;
+        int requested_cars = car_prop_buffers.size() > 0 ? car_prop_buffers.size() : 1;
+        PhysicsCarProperties* props_array = nullptr;
+        cars = gamestate_data.create_and_allocate_cars(requested_cars, &props_array);
+        car_properties_array = props_array;
+        num_cars = requested_cars;
         for (int i = 0; i < num_cars; i++)
         {
                 cars[i].mtxa = &mtxa;
@@ -472,6 +472,9 @@ void GameSim::instantiate_gamesim(StreamPeerBuffer* lvldat_buf, godot::Array car
                         godot::Ref<godot::StreamPeerBuffer> pb = godot::Ref<godot::StreamPeerBuffer>(memnew(godot::StreamPeerBuffer));
                         pb->set_data_array(arr);
                         *(cars[i].car_properties) = PhysicsCarProperties::deserialize(*pb);
+                }
+                if (i < accel_settings.size() && accel_settings[i].get_type() == godot::Variant::FLOAT) {
+                        cars[i].m_accel_setting = accel_settings[i];
                 }
                 cars[i].initialize_machine();
 

--- a/src/main.h
+++ b/src/main.h
@@ -52,7 +52,7 @@ namespace godot {
 			void set_car_node_container(godot::Node3D* p_car_node_container) { car_node_container = p_car_node_container; }
 			godot::Node3D* get_car_node_container() const { return car_node_container; }
                         void tick_gamesim(godot::Array player_inputs);
-                       void instantiate_gamesim(StreamPeerBuffer* in_buffer, godot::Array car_prop_buffers);
+                       void instantiate_gamesim(StreamPeerBuffer* in_buffer, godot::Array car_prop_buffers, godot::Array accel_settings);
                        void destroy_gamesim();
                        void render_gamesim();
                        void save_state();


### PR DESCRIPTION
## Summary
- expose acceleration settings when instantiating the game sim
- allow Godot side to pass chosen car definitions and acceleration settings
- propagate accel settings to PhysicsCar objects

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a4b0b3c90832d837d4b7482b99feb