### PR TITLE
Listen server uses client prediction

### DIFF
--- a/mxto/main.gd
+++ b/mxto/main.gd
@@ -200,10 +200,10 @@ func _physics_process(delta: float) -> void:
 		if players.size() > local_player_index:
 			local_input = players[local_player_index].get_input().to_dict()
 		network_manager.set_local_input(local_input)
-		if network_manager.is_server:
-			_simulate_multiple_ticks()   # keep old while-loop
-		else:
-			_simulate_single_tick()      # new, client version
+                if network_manager.is_server and !network_manager.listen_host:
+                        _simulate_multiple_ticks()   # keep old while-loop
+                else:
+                        _simulate_single_tick()      # new, client or listen server version
 		game_sim.render_gamesim()
 		_check_race_finished()
 


### PR DESCRIPTION
## Summary
- allow NetworkManager to operate in listen server mode with client-side prediction
- update physics simulation loop for listen servers

## Testing
- `scons -Q` *(fails: Missing SConscript 'godot-cpp/SConstruct')*

------
https://chatgpt.com/codex/tasks/task_e_685c50520678832d90436ff6665f5c17