### PR TITLE
Enable host client prediction mode

### DIFF
--- a/mxto/main.gd
+++ b/mxto/main.gd
@@ -200,10 +200,12 @@ func _physics_process(delta: float) -> void:
 		if players.size() > local_player_index:
 			local_input = players[local_player_index].get_input().to_dict()
 		network_manager.set_local_input(local_input)
-		if network_manager.is_server:
-			_simulate_multiple_ticks()   # keep old while-loop
-		else:
-			_simulate_single_tick()      # new, client version
+                if network_manager.is_server:
+                        _simulate_multiple_ticks()   # keep old while-loop
+                        if network_manager.host_client_mode:
+                                _simulate_single_tick()      # host client view
+                else:
+                        _simulate_single_tick()      # new, client version
 		game_sim.render_gamesim()
 		_check_race_finished()
 
@@ -215,7 +217,7 @@ func _simulate_multiple_ticks():
 		if players.size() > local_player_index:
 			local_input = players[local_player_index].get_input().to_dict()
 		network_manager.set_local_input(local_input)
-		var frame_inputs := network_manager.collect_inputs()
+                var frame_inputs := network_manager.collect_inputs(true)
 		if frame_inputs.is_empty():
 			break
 		game_sim.tick_gamesim(frame_inputs)


### PR DESCRIPTION
## Summary
- allow the host to run client-side prediction
- add `host_client_mode` to `NetworkManager`
- process server broadcasts locally when hosting
- simulate an extra client tick for the host

## Testing
- `scons -Q` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c608096d8832db3bae11b79e42317